### PR TITLE
only define window.Page if undefined

### DIFF
--- a/lib/assets/javascripts/page.coffee
+++ b/lib/assets/javascripts/page.coffee
@@ -1,4 +1,4 @@
-window.Page = {}
+window.Page = {} if !window.Page
 
 Page.visit = (url, opts={}) ->
   if opts.reload


### PR DESCRIPTION
cc @nsimmons 
we need this, since we want window.Page to be something different
At least, I'm pretty sure we need this
