### PR TITLE
Bugfix/28 compute redirect to location signature

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@ Thanks go out to:
 - Patrick Donovan ([patrickdonovan](https://github.com/patrickdonovan))
 - Kristian PD ([kristianpd](https://github.com/kristianpd))
 - Nicholas Simmons ([nsimmons](https://github.com/nsimmons))
+- David Muto ([pseudomuto](https://github.com/pseudomuto))

--- a/lib/turbograft/xhr_headers.rb
+++ b/lib/turbograft/xhr_headers.rb
@@ -17,13 +17,24 @@ module TurboGraft
 
     private
 
-    def _compute_redirect_to_location_with_xhr_referer(options)
-      session[:_turbolinks_redirect_to] =
-        if options == :back && request.headers["X-XHR-Referer"]
-          call_original(request.headers["X-XHR-Referer"])
-        else
-          call_original(options)
-        end
+    if Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR > 1
+      def _compute_redirect_to_location_with_xhr_referer(request, options)
+        session[:_turbolinks_redirect_to] =
+          if options == :back && request.headers["X-XHR-Referer"]
+            _compute_redirect_to_location_without_xhr_referer(request, request.headers["X-XHR-Referer"])
+          else
+            _compute_redirect_to_location_without_xhr_referer(request, options)
+          end
+      end
+    else
+      def _compute_redirect_to_location_with_xhr_referer(options)
+        session[:_turbolinks_redirect_to] =
+          if options == :back && request.headers["X-XHR-Referer"]
+            _compute_redirect_to_location_without_xhr_referer(request.headers["X-XHR-Referer"])
+          else
+            _compute_redirect_to_location_without_xhr_referer(options)
+          end
+      end
     end
 
     def set_xhr_redirected_to
@@ -31,14 +42,5 @@ module TurboGraft
         response.headers['X-XHR-Redirected-To'] = session.delete :_turbolinks_redirect_to
       end
     end
-
-    def call_original(options)
-      if Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR >= 1
-        _compute_redirect_to_location_without_xhr_referer(request, options)
-      else
-        _compute_redirect_to_location_without_xhr_referer(options)
-      end
-    end
   end
-
 end


### PR DESCRIPTION
@nsimmons, @qq99 for review

I realize that this is ugly, but since we're using `alias_method_chain` I didn't see another option.

Rails 4.2+ has a different signature for this method, so we need to support two versions of `_compute_redirect_to_location_with_xhr_referer`. 

See https://github.com/rails/rails/blob/001e600619c7ec5d7535e47c5900bcad259de3f8/actionpack/lib/action_controller/metal/redirecting.rb for the updated version.

Fixes #28 
