### PR TITLE
Adding contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,42 @@
-# PR Guidelines
+## Reporting a Bug
 
-* Make each pull request atomic and exclusive; don't send pull requests for a laundry list of changes.
-* Even better, commit in small manageable chunks.
-* Make sure there are tests associated with your PR such that they fail without the code you've
-    added
-* Label your PR with one of `Major Release`, `Minor Release` or `Patch Release` as outlined at
-    <http://semver.org>.
-* Tag a few [contributors](CONTRIBUTORS.md) for review
+Think you've found a bug or have a new feature to suggest? Let us know!
+
+1. Update to the most recent master release if possible. We may have already fixed your bug.
+
+2. Search for similar issues. It's possible somebody has encountered this bug already.
+
+3. Please make sure you provide very specific steps to reproduce the error. If we cannot reproduce
+it, we will close the ticket.
+
+4. If possible, submit a Pull Request with a failing test. Better yet, take a stab at fixing the bug
+yourself if you can!
+
+The more information you provide, the easier it is for us to validate that there is a bug and the
+faster we'll be able to take action.
+
+## Requesting a Feature
+
+1. Search Issues for similar feature requests. It's possible somebody has already asked for this
+feature or provided a pull request that we're still discussing.
+
+2. Provide a clear and detailed explanation of the feature you want and why it's important to add.
+Keep in mind that we want features that will be useful to the majority of our users and not just a
+small subset.
+
+3. If the feature is complex, consider writing some initial documentation for it. If we do end up
+accepting the feature it will need to be documented and this will also help us to understand it
+better ourselves.
+
+4. Attempt a Pull Request. If you're at all able, start writing some code. We always have more work
+to do than time to do it. If you can write some code then that will speed the process along.
+
+## Code Changes
+
+When opening a PR, please include the following:
+
+1. Keep code changes simple. Always ask, "Is the code as simple as I can make it?"
+
+2. Explain what the change does and why it is needed.
+
+3. Write tests for your code


### PR DESCRIPTION
I've added some contributing guidelines for us to use. Specifically, I want to document the use of the `Major/Minor/Patch Release` labels I've added.

This way when we're going to release a new version of the gem, we can look at the list of PRs since the last release to determine what the new version should be.

What do you guys think?

@tylermercier @nsimmons @qq99 
