### PR TITLE
Tweaking remote-form and remote-method to become tg-remote

### DIFF
--- a/lib/assets/javascripts/turbograft/initializers.coffee
+++ b/lib/assets/javascripts/turbograft/initializers.coffee
@@ -22,15 +22,15 @@ TurboGraft.handlers.partialGraftClickHandler = (ev) ->
 
 TurboGraft.handlers.remoteMethodHandler = (ev) ->
   target = ev.target
-  httpRequestType = target.getAttribute('remote-method')
+  httpRequestType = target.getAttribute('tg-remote')
   return unless httpRequestType
   ev.preventDefault()
   httpUrl = target.getAttribute('href')
-  throw new Error("Turbograft developer error: You did not provide a URL for remote-method") unless httpUrl
+  throw new Error("Turbograft developer error: You did not provide a URL ('href' attribute) for tg-remote") unless httpUrl
 
   if target.getAttribute("remote-once")
     target.removeAttribute("remote-once")
-    target.removeAttribute("remote-method")
+    target.removeAttribute("tg-remote")
 
   options =
     httpRequestType: httpRequestType
@@ -44,19 +44,17 @@ TurboGraft.handlers.remoteMethodHandler = (ev) ->
     options.fullRefresh = true
 
   remote = new TurboGraft.Remote(options, null, target)
+  remote.submit()
   return
 
 TurboGraft.handlers.remoteFormHandler = (ev) ->
   target = ev.target
-  return unless target.getAttribute('remote-form')?
+  return unless target.getAttribute('tg-remote')?
   ev.preventDefault()
   httpUrl = target.getAttribute('action')
-  httpRequestType = target.getAttribute('method')
-  throw new Error("Turbograft developer error: You did not provide a request type for remote-method") unless httpRequestType
-  throw new Error("Turbograft developer error: You did not provide a URL for remote-method") unless httpUrl
+  throw new Error("Turbograft developer error: You did not provide a URL ('action' attribute) for tg-remote") unless httpUrl
 
   options =
-    httpRequestType: httpRequestType
     httpUrl: httpUrl
     fullRefresh: target.getAttribute('full-refresh')?
     refreshOnSuccess: target.getAttribute('refresh-on-success')
@@ -67,6 +65,7 @@ TurboGraft.handlers.remoteFormHandler = (ev) ->
     options.fullRefresh = true
 
   remote = new TurboGraft.Remote(options, target, target)
+  remote.submit()
   return
 
 documentListenerForButtons = (eventType, handler, useCapture = false) ->

--- a/test/browser/partial_page_refresh_test.rb
+++ b/test/browser/partial_page_refresh_test.rb
@@ -67,25 +67,41 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "remote-method on a link with GET and refresh-on-success and status 200" do
+  test "tg-remote on a link with GET and refresh-on-success and status 200" do
     assert page.has_content?("page 1")
     old_location = current_url
 
-    click_link "remote-method GET to response of 200"
+    click_link "tg-remote GET to response of 200"
 
     new_location = current_url
     refute page.has_content?("Page 1")
     assert_equal new_location, old_location
   end
 
-  test "remote-method on a link with GET and refresh-on-error and status 422" do
+  test "tg-remote on a link with GET and refresh-on-error and status 422" do
     assert page.has_content?("page 1")
     old_location = current_url
 
-    click_link "remote-method GET to response of 422"
+    click_link "tg-remote GET to response of 422"
 
     new_location = current_url
     assert page.has_content?("Error 422!")
     assert_equal new_location, old_location
+  end
+
+  test "tg-remote on a form with post, in status codes: 422 and 200" do
+    click_button "Submit tg-remote POST"
+    assert page.has_content?("Please supply a foo!")
+
+    page.fill_in 'foo', :with => 'some text'
+    click_button "Submit tg-remote POST"
+
+    refute page.has_content?("Please supply a foo!")
+    assert page.has_content?("Thanks for the foo! We'll consider it.")
+  end
+
+  test "tg-remote on a form with patch" do
+    click_button "Submit tg-remote PATCH"
+    assert page.has_content?("Thanks, we got your patch.")
   end
 end

--- a/test/example/app/controllers/pages_controller.rb
+++ b/test/example/app/controllers/pages_controller.rb
@@ -44,6 +44,10 @@ class PagesController < ApplicationController
     end
   end
 
+  def patch_foo
+    render '_patched_foo', status: 200, layout: false
+  end
+
   def new
     render json: "{}", location: 'http://www.notexample.com'
   end

--- a/test/example/app/views/pages/_patched_foo.html.erb
+++ b/test/example/app/views/pages/_patched_foo.html.erb
@@ -1,0 +1,3 @@
+<div id="foo-results2" refresh="foo-results2">
+Thanks, we got your patch.
+</div>

--- a/test/example/app/views/pages/show.html.erb
+++ b/test/example/app/views/pages/show.html.erb
@@ -135,16 +135,16 @@
 </section>
 
 <section>
-  <h1>remote-method</h1>
+  <h1>tg-remote links</h1>
   <p>This provides functionality similar to rails version of link_to for methods other than GET, allowing you to query methods on different endpoints, and partial page replacing different refresh keys depending on the response status.</p>
   <p>It requires your node to be marked up with:</p>
   <ul>
-    <li><code>remote-method</code>: the HTTP method you wish to call on your endpoint</li>
+    <li><code>tg-remote</code>: the HTTP method you wish to call on your endpoint</li>
     <li><code>href</code>: the URL of the endpoint you wish to hit</li>
     <li><code>refresh-on-success</code>: (optional, but you'll almost always want it) which refresh keys will get refreshed, using the body of the response. This is space-delimited</li>
     <li><code>refresh-on-error</code>: (optional) see above, but using body of XHR that has failed.  Only works with error 422</li>
     <li><code>full-refresh-on-error-except</code>: (optional) replaces body except passed id, but using body of XHR that has failed.  Only works with error 422</li>
-    <li><code>remote-once</code>: (optional) Only do this once. Removes remote-method and remote-once from element after consumption</li>
+    <li><code>remote-once</code>: (optional) Only do this once. Removes <code>tg-remote</code> and <code>remote-once</code> from element after consumption</li>
     <li><code>full-refresh</code>: Instead of using the content of the XHR response for partial page replacement, we will instead re-GET the URL in question.  Defaults to <code>true</code> if neither <code>refresh-on-success</code> nor <code>refresh-on-error</code> are provided.</li>
   </ul>
   <p>It emits a few events:</p>
@@ -156,34 +156,33 @@
     <li><code>turbograft:remote:fail</code>: always fires when XHR failed</li>
     <li><code>turbograft:remote:fail:unhandled</code>: fires after the above event, but when we didn't partially replace anything with refresh-on-error (because there was no refresh-on-error supplied)</li>
   </ul>
-  <p>Each event also is sent with a copy of the xhr in case you need to look at anything in there, as well as a reference to the element that initated the remote-method.</p>
+  <p>Each event also is sent with a copy of the xhr in case you need to look at anything in there, as well as a reference to the element that initated the <code>remote</code>.</p>
 
 
 <div class="prepend-pre">
-<a href="<%= page_path(rand(100)) %>" remote-method="GET" refresh-on-success="page section-a section-b">remote-method GET to response of 200</a>
+<a href="<%= page_path(rand(100)) %>" tg-remote="GET" refresh-on-success="page section-a section-b">tg-remote GET to response of 200</a>
 </div>
 
 <div class="prepend-pre">
-<a href="<%= error_422_pages_path %>" remote-method="GET" refresh-on-error="page">remote-method GET to response of 422</a>
+<a href="<%= error_422_pages_path %>" tg-remote="GET" refresh-on-error="page">tg-remote GET to response of 422</a>
 </div>
 
 <div class="prepend-pre">
-<a href="<%= error_422_with_show_pages_path %>" remote-method="GET" full-refresh-on-error-except="section-a">remote-method GET to response of 422 replaces everything except side-bar-a</a>
+<a href="<%= error_422_with_show_pages_path %>" tg-remote="GET" full-refresh-on-error-except="section-a">tg-remote GET to response of 422 replaces everything except side-bar-a</a>
 </div>
 
 <div class="prepend-pre">
-<a href="<%= error_404_pages_path %>" remote-method="GET">remote-method GET to response of 404</a>
+<a href="<%= error_404_pages_path %>" tg-remote="GET">tg-remote GET to response of 404</a>
 </div>
   <p><code>refresh-on-error</code> only works for error 422.  This is mainly so you can refresh certain a part of a form (e.g., validation error div) when returning 422.  Nothing changes if the XHR errors out if you do not supply a <code>refresh-on-error</code>.</p>
 </section>
 
 <section>
-  <h1>remote-form</h1>
+  <h1>tg-remote forms</h1>
   <p>It requires your <code>form</code> to be marked up with:</p>
   <ul>
-    <li><code>remote-form</code>: an attribute that doesn't need a value</li>
+    <li><code>tg-remote</code>: an attribute that doesn't need a value</li>
     <li><code>action</code>: you should have one of these already</li>
-    <li><code>method</code>: you should have one of these already</li>
     <li><code>refresh-on-success</code>: (optional, but you'll almost always want it) which refresh keys will get refreshed, using the body of the response. This is space-delimited</li>
     <li><code>refresh-on-error</code>: (optional) see above, but using body of XHR that has failed.  Only works with error 422</li>
     <li><code>full-refresh-on-error-except</code>: (optional) replaces body except passed id, but using body of XHR that has failed.  Only works with error 422</li>
@@ -199,16 +198,35 @@
     <li><code>turbograft:remote:fail:unhandled</code>: fires after the above event, but when we didn't partially replace anything with refresh-on-error (because there was no refresh-on-error supplied)</li>
   </ul>
 
+<h3>Example of tg-remote form: POST</h3>
 <div class="prepend-pre">
 <div id="foo-results" refresh="foo-results">
   Use the field below to submit some content, and get a result.
 </div>
-<form remote-form action="/pages/submit_foo" method="post" refresh-on-success="foo-results foo-errors" refresh-on-error="foo-results foo-errors">
-  <input name="foo" type="text">
-  <button type="submit">Submit</button>
+<form tg-remote action="/pages/submit_foo" method="post" refresh-on-success="foo-results foo-errors" refresh-on-error="foo-results foo-errors">
+  <input id="foo" name="foo" type="text">
+  <button type="submit">Submit tg-remote POST</button>
 </form>
 </div>
 </section>
+
+<h3>Example of tg-remote form: PATCH</h3>
+<div class="prepend-pre">
+<div id="foo-results2" refresh="foo-results2">
+
+</div>
+<form tg-remote action="/pages/patch_foo" method="post" refresh-on-success="foo-results2">
+  <input type="hidden" name="_method" value="patch">
+  <input type="radio" name="someradio" value="A">
+  <input type="radio" name="someradio" value="B">
+  <input type="radio" name="someradio" value="C">
+  <input type="checkbox" name="somecheck" value="1">
+  <input type="text" name="disabled_textbox" disabled value="Disabled">
+  <input type="text" name="readonly_textbox" readonly value="Readonly">
+  <br>
+  <input type="submit" value="Submit tg-remote PATCH">
+</form>
+</div>
 
 <section>
   <h1>Other features</h1>

--- a/test/example/config/routes.rb
+++ b/test/example/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       get :error_422_with_show
       post :redirect_to_somewhere_else_after_POST
       post :submit_foo
+      patch :patch_foo
     end
   end
 end

--- a/test/javascripts/initializers_test.coffee
+++ b/test/javascripts/initializers_test.coffee
@@ -35,16 +35,16 @@ describe 'Initializers', ->
       $button[0].click()
       assert.equal 0, @refreshStub.callCount, "Refresh was called when it shouldn't have been"
 
-  describe 'remote-method', ->
+  describe 'tg-remote on links', ->
     beforeEach ->
-      @Remote = stub(TurboGraft, "Remote")
+      @Remote = stub(TurboGraft, "Remote").returns({submit: ->})
 
     afterEach ->
       @Remote.restore()
 
     it 'creates a remote based on the options passed in', ->
       $link = $("<a>")
-        .attr("remote-method", "GET")
+        .attr("tg-remote", "GET")
         .attr("refresh-on-success", "foo")
         .attr("refresh-on-error", "bar")
         .attr("full-refresh-on-error-except", "zar")
@@ -62,7 +62,7 @@ describe 'Initializers', ->
 
     it 'passes through null for missing refresh-on-success', ->
       $link = $("<a>")
-        .attr("remote-method", "GET")
+        .attr("tg-remote", "GET")
         .attr("refresh-on-error", "bar")
         .attr("href", "somewhere")
 
@@ -76,9 +76,9 @@ describe 'Initializers', ->
         refreshOnError: "bar"
         refreshOnErrorExcept: null
 
-    it 'respects remote-method supplied', ->
+    it 'respects tg-remote supplied', ->
       $link = $("<a>")
-        .attr("remote-method", "PATCH")
+        .attr("tg-remote", "PATCH")
         .attr("refresh-on-error", "bar")
         .attr("href", "somewhere")
 
@@ -94,7 +94,7 @@ describe 'Initializers', ->
 
     it 'passes through null for missing refresh-on-error', ->
       $link = $("<a>")
-        .attr("remote-method", "GET")
+        .attr("tg-remote", "GET")
         .attr("refresh-on-success", "foo")
         .attr("href", "somewhere")
 
@@ -110,7 +110,7 @@ describe 'Initializers', ->
 
     it 'passes through null for missing full-refresh-on-error-except', ->
       $link = $("<a>")
-        .attr("remote-method", "GET")
+        .attr("tg-remote", "GET")
         .attr("full-refresh-on-error-except", "zew")
         .attr("href", "somewhere")
 
@@ -127,7 +127,7 @@ describe 'Initializers', ->
     it 'respects full-refresh', ->
       $link = $("<a>")
         .attr("full-refresh", true)
-        .attr("remote-method", "GET")
+        .attr("tg-remote", "GET")
         .attr("refresh-on-success", "foo")
         .attr("refresh-on-error", "bar")
         .attr("href", "somewhere")
@@ -144,7 +144,7 @@ describe 'Initializers', ->
 
     it 'will use a full-refresh if neither refresh-on-success nor refresh-on-error are provided', ->
       $link = $("<a>")
-        .attr("remote-method", "GET")
+        .attr("tg-remote", "GET")
         .attr("href", "somewhere")
 
       $("body").append($link)
@@ -160,7 +160,7 @@ describe 'Initializers', ->
     it 'does nothing if disabled', ->
       $link = $("<a>")
         .attr("disabled", "disabled")
-        .attr("remote-method", "GET")
+        .attr("tg-remote", "GET")
         .attr("refresh-on-success", "foo")
         .attr("refresh-on-error", "bar")
         .attr("href", "somewhere")

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -13,6 +13,7 @@ describe 'Remote', ->
         httpRequestType: "GET"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
       request = server.requests[0]
       assert.equal "/foo/bar", request.url
@@ -24,6 +25,7 @@ describe 'Remote', ->
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
       request = server.requests[0]
       assert.equal "/foo/bar", request.url
@@ -35,6 +37,7 @@ describe 'Remote', ->
         httpRequestType: "PUT"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
       request = server.requests[0]
       assert.equal "/foo/bar", request.url
@@ -46,6 +49,7 @@ describe 'Remote', ->
         httpRequestType: "PATCH"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
       request = server.requests[0]
       assert.equal "/foo/bar", request.url
@@ -57,6 +61,7 @@ describe 'Remote', ->
         httpRequestType: "DELETE"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
       request = server.requests[0]
       assert.equal "/foo/bar", request.url
@@ -73,6 +78,7 @@ describe 'Remote', ->
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
       request = server.requests[0]
       assert.equal "anything", request.requestHeaders["X-CSRF-Token"]
@@ -87,6 +93,7 @@ describe 'Remote', ->
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
     it 'if provided a target on creation, will provide this as data in events', (done) ->
       $(@initiating_target).one "turbograft:remote:start", (ev, a) ->
@@ -98,6 +105,7 @@ describe 'Remote', ->
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
     it 'will trigger turbograft:remote:success on success with the XHR as the data', (done) ->
       $(@initiating_target).one "turbograft:remote:fail", (ev) ->
@@ -115,6 +123,7 @@ describe 'Remote', ->
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
       server.respond()
 
@@ -138,6 +147,7 @@ describe 'Remote', ->
         httpUrl: "/foo/bar"
         refreshOnError: "foo"
       , @initiating_target
+      remote.submit()
 
       server.respond()
 
@@ -157,6 +167,7 @@ describe 'Remote', ->
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
       server.respond()
 
@@ -173,6 +184,7 @@ describe 'Remote', ->
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
       server.respond()
 
@@ -189,6 +201,7 @@ describe 'Remote', ->
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
       server.respond()
 
@@ -210,6 +223,7 @@ describe 'Remote', ->
         httpUrl: "/foo/bar"
         refreshOnSuccess: "a b c"
       , @initiating_target
+      remote.submit()
 
       server.respond()
       assert @refreshStub.calledWith
@@ -227,6 +241,7 @@ describe 'Remote', ->
         refreshOnSuccess: "a b c"
         fullRefresh: true
       , @initiating_target
+      remote.submit()
 
       server.respond()
 
@@ -243,6 +258,7 @@ describe 'Remote', ->
         httpUrl: "/foo/bar"
         fullRefresh: true
       , @initiating_target
+      remote.submit()
 
       server.respond()
 
@@ -260,6 +276,7 @@ describe 'Remote', ->
         refreshOnError: "a b c"
         fullRefresh: true
       , @initiating_target
+      remote.submit()
 
       server.respond()
 
@@ -277,7 +294,53 @@ describe 'Remote', ->
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
       , @initiating_target
+      remote.submit()
 
       server.respond()
 
       assert.equal 0, @refreshStub.callCount
+
+  describe 'serialization', ->
+
+    it 'will create FormData object if there is a file in the form', ->
+      form = $("<form><input type='file' name='foo'></form>")[0]
+
+      remote = new TurboGraft.Remote({}, form)
+      assert (remote.formData instanceof FormData)
+
+    it 'will not create FormData object if there is no file in the form', ->
+      form = $("<form><input type='text' name='foo' value='bar'></form>")[0]
+
+      remote = new TurboGraft.Remote({}, form)
+      assert.equal "foo=bar", remote.formData
+
+    it 'properly URL encodes multiple fields in the form', ->
+      formDesc = """
+      <form>
+        <input type="text" name="foo" value="bar">
+        <input type="text" name="faa" value="bat">
+        <textarea name="textarea">this is a test</textarea>
+        <input type="text" name="disabled" disabled value="disabled">
+        <input type="radio" name="radio1" value="A">
+        <input type="radio" name="radio1" value="B" checked>
+        <input type="checkbox" name="checkbox" value="C">
+        <input type="checkbox" name="checkbox" value="D" checked>
+        <input type="checkbox" name="disabled2" value="checked" checked disabled>
+        <select name="select1">
+          <option value="a">foo</option>
+          <option value="b">foo</option>
+          <option value="c" selected>foo</option>
+        </select>
+        <input type="text" name="foobar" value="foobat">
+      </form>
+      """
+      form = $(formDesc)[0]
+
+      remote = new TurboGraft.Remote({}, form)
+      assert.equal "foo=bar&faa=bat&textarea=this%20is%20a%20test&radio1=B&checkbox=D&select1=c&foobar=foobat", remote.formData
+
+    it 'will set content type on XHR proplery when form is URL encoded', ->
+      form = $("<form><input type='text' name='foo' value='bar'></form>")[0]
+
+      remote = new TurboGraft.Remote({}, form)
+      assert.equal "application/x-www-form-urlencoded; charset=UTF-8", remote.xhr.requestHeaders["Content-Type"]


### PR DESCRIPTION
- Rename `remote-method` and `remote-form` to be simply `tg-remote` (namespaced cause rails is a jerk and infers `remote` in any context to become `data-remote` ;)
- Remove `method` attribute being required on a `form` for `remote-form`, as rails specifies method with a hidden field `_method` and does `GET` or `POST` anyway
- Serializes forms submitted with `TurboGraft.Remote` in a much smarter manner (payload size drastically reduced for purely input based forms, was previously using FormData)

TODO:
- [ ] put a breaking change notice in release notes
