### PR TITLE
fix pageChangePrevented method

### DIFF
--- a/lib/assets/javascripts/turbograft/click.coffee
+++ b/lib/assets/javascripts/turbograft/click.coffee
@@ -15,11 +15,8 @@ class window.Click
     return if @event.defaultPrevented
     @_extractLink()
     if @_validForTurbolinks()
-      Turbolinks.visit @link.href unless @_pageChangePrevented()
+      Turbolinks.visit @link.href
       @event.preventDefault()
-
-  _pageChangePrevented: ->
-    !triggerEvent 'page:before-change' # TODO: fix this global
 
   _extractLink: ->
     link = @event.target

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -56,6 +56,7 @@ class window.Turbolinks
   referer = null
 
   fetch = (url, partialReplace = false, replaceContents = [], callback) ->
+    return if pageChangePrevented(url)
     url = new ComponentUrl url
 
     rememberReferer()
@@ -233,8 +234,8 @@ class window.Turbolinks
     else
       window.scrollTo 0, 0
 
-  pageChangePrevented = ->
-    !triggerEvent 'page:before-change'
+  pageChangePrevented = (url) ->
+    !triggerEvent('page:before-change', url)
 
   processResponse = (xhr, partial = false) ->
     clientOrServerError = ->

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -62,6 +62,18 @@ describe 'Turbolinks', ->
     assert Turbolinks
 
   describe '#visit', ->
+    it 'returns if pageChangePrevented', ->
+      listener = (event) ->
+        event.preventDefault()
+        assert.equal '/some_request', event.data
+
+      window.addEventListener('page:before-change', listener)
+
+      Turbolinks.visit "/some_request", true, ['turbo-area']
+      assert.equal 0, @server.requests.length
+
+      window.removeEventListener('page:before-change', listener)
+
     describe 'with partial page replacement', ->
       it 'uses just the part of the response body we supply', ->
         @server.respondWith([200, { "Content-Type": "text/html" }, html_one]);


### PR DESCRIPTION
while working on some new features for `form.coffee` in Shopify I discovered that the `page:before-change` event and the `pageChangePrevented` code is not consistent or working properly. `pageChangePrevented` was defined in `turbolinks.coffee` but never used and redefined in `click.coffee` with an underscore prepended. The code was actually used in the `click.coffee` code to fire the event and stop the request if the event returned false. This seems to stem from our refactor of turbolinks into separate files.
# Changes
- check pageChangePrevented in turbolinks#fetch
- now that pageChangePrevented is checked in fetch remove dead code from click.coffee
- add a proper test for pageChangePrevented
- send the turbolink url in the event.data (tested)

I checked the original turbolinks module and they have the same issue I noticed here - `pageChangePrevented` is only fired from the `click` code rather than checking inside of fetch. I can't see any reason for this - the only other thing that calls fetch is from the history handler and its working fine for me.

for review
@nsimmons @pushrax @qq99

I also bumped the version to 0.0.9 so we can ship this separate from the other things in the queue
