### PR TITLE
sometimes there's no target in the event :o

### DIFF
--- a/lib/assets/javascripts/turbograft/initializers.coffee
+++ b/lib/assets/javascripts/turbograft/initializers.coffee
@@ -71,6 +71,7 @@ TurboGraft.handlers.remoteFormHandler = (ev) ->
 documentListenerForButtons = (eventType, handler, useCapture = false) ->
   document.addEventListener eventType, (ev) ->
     target = ev.target
+    return if !target
     isNodeDisabled = nodeIsDisabled(target)
     ev.preventDefault() if isNodeDisabled
     return if !(target.nodeName == "A" || target.nodeName == "BUTTON") || isNodeDisabled


### PR DESCRIPTION
Fixes a bug we rarely see
Sometimes there is no target during a click event

I do not know how

cc @patrickdonovan 
