### PR TITLE
Change method used to encode formData

### DIFF
--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -66,7 +66,7 @@ class TurboGraft.Remote
 
       if inputEnabled && input.name
         if (radioOrCheck && input.checked) || !radioOrCheck
-          formData += "#{encodeURI(input.name)}=#{encodeURI(input.value)}&"
+          formData += "#{encodeURIComponent(input.name)}=#{encodeURIComponent(input.value)}&"
 
     formData = formData.slice(0,-1) if formData.charAt(formData.length - 1) == "&"
     formData

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -319,6 +319,7 @@ describe 'Remote', ->
       <form>
         <input type="text" name="foo" value="bar">
         <input type="text" name="faa" value="bat">
+        <input type="text" name="fii" value="bam+">
         <textarea name="textarea">this is a test</textarea>
         <input type="text" name="disabled" disabled value="disabled">
         <input type="radio" name="radio1" value="A">
@@ -337,9 +338,9 @@ describe 'Remote', ->
       form = $(formDesc)[0]
 
       remote = new TurboGraft.Remote({}, form)
-      assert.equal "foo=bar&faa=bat&textarea=this%20is%20a%20test&radio1=B&checkbox=D&select1=c&foobar=foobat", remote.formData
+      assert.equal "foo=bar&faa=bat&fii=bam%2B&textarea=this%20is%20a%20test&radio1=B&checkbox=D&select1=c&foobar=foobat", remote.formData
 
-    it 'will set content type on XHR proplery when form is URL encoded', ->
+    it 'will set content type on XHR properly when form is URL encoded', ->
       form = $("<form><input type='text' name='foo' value='bar'></form>")[0]
 
       remote = new TurboGraft.Remote({}, form)


### PR DESCRIPTION
Ran into issues with the authenticity_token being passed incorrectly to my server. The + sign was not being encoded properly before being sent, and was being received as a space character by my server.
Fixes #44

> encodeURI replaces all characters except the following with the appropriate UTF-8 escape sequences:
> 
> ```
> Type    Includes
> Reserved characters ; , / ? : @ & = + $
> nescaped characters alphabetic, decimal digits, - _ . ! ~ * ' ( )
> Score   #
> ```
> 
> Note that encodeURI by itself cannot form proper HTTP GET and POST requests, such as for XMLHTTPRequests, because "&", "+", and "=" are not encoded, which are treated as special characters in GET and POST requests. encodeURIComponent, however, does encode these characters.
> https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI

Changed it to use the [encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) instead.

``` javascript
encodeURI('+')
=> "+"
encodeURIComponent('+')
=> "%2B"
```

I also tested this out in my project and the authenticity_token is now correctly being passed.
