### PR TITLE
properly set the X-CSRF-Token header if it is present in the <head>

### DIFF
--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -17,6 +17,10 @@ class TurboGraft.Remote
     xhr.setRequestHeader('Accept', 'text/html, application/xhtml+xml, application/xml')
     xhr.setRequestHeader("Content-Type", @contentType) if @contentType
 
+    csrfTokenNode = document.querySelector('meta[name="X-CSRF-Token"]')
+    csrfToken = csrfTokenNode?.getAttribute('content')
+    xhr.setRequestHeader('X-CSRF-Token', csrfToken) if csrfToken
+
     triggerEventFor('turbograft:remote:init', @initiator, {xhr: xhr, initiator: @initiator})
 
     xhr.addEventListener 'loadstart', =>

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -71,7 +71,7 @@ describe 'Remote', ->
 
     it 'allows turbograft:remote:init to set a header', ->
       $(@initiating_target).one "turbograft:remote:init", (event) ->
-        event.originalEvent.data.xhr.setRequestHeader("X-CSRF-Token", "anything")
+        event.originalEvent.data.xhr.setRequestHeader("X-Header", "anything")
 
       server = sinon.fakeServer.create()
       remote = new TurboGraft.Remote
@@ -81,7 +81,23 @@ describe 'Remote', ->
       remote.submit()
 
       request = server.requests[0]
-      assert.equal "anything", request.requestHeaders["X-CSRF-Token"]
+      assert.equal "anything", request.requestHeaders["X-Header"]
+
+    it 'will automatically set the X-CSRF-Token header for you', ->
+      $fakeCsrfNode = $("<meta>").attr("name", "X-CSRF-Token").attr("content", "some-token")
+      $("head").append($fakeCsrfNode)
+
+      server = sinon.fakeServer.create()
+      remote = new TurboGraft.Remote
+        httpRequestType: "POST"
+        httpUrl: "/foo/bar"
+      , @initiating_target
+      remote.submit()
+
+      request = server.requests[0]
+      assert.equal "some-token", request.requestHeaders["X-CSRF-Token"]
+
+      $('meta[name="X-CSRF-Token"]').remove()
 
     it 'will trigger turbograft:remote:start on start with the XHR as the data', (done) ->
       $(@initiating_target).one "turbograft:remote:start", (ev) ->


### PR DESCRIPTION
@kurtfunai:  @celsodantas told me about the bug you found.  Great catch!  We actually had an event listener setting the `X-CSRF-Token` header on the XHR before it was sent, but now I realize that's pretty silly.

This PR hopes to address it

cc @nsimmons @tylermercier 
