### PR TITLE
attempt to add proper support for delegated events

### DIFF
--- a/test/browser/partial_page_refresh_test.rb
+++ b/test/browser/partial_page_refresh_test.rb
@@ -46,14 +46,6 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     assert_not_equal random_b, find('#random-number-b').text
   end
 
-  test "partial-graft helper works" do
-    random_a = find('#random-number-a').text
-    random_b = find('#random-number-b').text
-    click_button "Partial Graft Helper: A and B"
-    assert_not_equal random_a, find('#random-number-a').text
-    assert_not_equal random_b, find('#random-number-b').text
-  end
-
   test "when I use an XHR and POST to an endpoint that returns me a 302, I should see the URL reflecting that redirect too" do
     assert page.has_content?("page 1")
     old_location = current_url

--- a/test/example/app/views/pages/show.html.erb
+++ b/test/example/app/views/pages/show.html.erb
@@ -66,15 +66,6 @@
     onlyKeys: ['section-a', 'section-b']
   });">Refresh Section A and B</button>
 </div>
-
-  <p>It's a bit ugly and cumbersome to need to write an <code>onclick</code> handler like this, so instead, we provide a helper that does the same thing:</p>
-<div class="prepend-pre">
-<button href="<%= page_path(@id) %>" partial-graft refresh="section-a section-b">Partial Graft Helper: A and B</button>
-</div>
-
-  <p>Just add the attribute, <code>partial-graft</code>.</p>
-
-
 </section>
 
 <section>
@@ -160,7 +151,9 @@
 
 
 <div class="prepend-pre">
-<a href="<%= page_path(rand(100)) %>" tg-remote="GET" refresh-on-success="page section-a section-b">tg-remote GET to response of 200</a>
+<a href="<%= page_path(rand(100)) %>" tg-remote="GET" refresh-on-success="page section-a section-b">
+  <i>tg-remote GET to response of 200</i>
+</a>
 </div>
 
 <div class="prepend-pre">

--- a/test/javascripts/initializers_test.coffee
+++ b/test/javascripts/initializers_test.coffee
@@ -1,40 +1,5 @@
 describe 'Initializers', ->
 
-  describe 'partial-graft', ->
-    beforeEach ->
-      @refreshStub = stub(Page, "refresh")
-
-    afterEach ->
-      @refreshStub.restore()
-
-    it 'calls Page.refresh when all required attributes are present', ->
-      $link = $("<a partial-graft>").attr("href", "/foo").attr("refresh", "foo bar")
-      $("body").append($link)
-      $link[0].click()
-      assert @refreshStub.calledWith
-        url: "/foo",
-        onlyKeys: ['foo', 'bar']
-
-    it 'does nothing when the link is disabled ', ->
-      $link = $("<a partial-graft>").attr("disabled", "disabled").attr("href", "/foo").attr("refresh", "foo bar")
-      $("body").append($link)
-      $link[0].click()
-      assert.equal 0, @refreshStub.callCount, "Refresh was called when it shouldn't have been"
-
-    it 'works on buttons too', ->
-      $button = $("<button partial-graft>").attr("href", "/foo").attr("refresh", "foo bar")
-      $("body").append($button)
-      $button[0].click()
-      assert @refreshStub.calledWith
-        url: "/foo",
-        onlyKeys: ['foo', 'bar']
-
-    it 'does nothing when the button is disabled ', ->
-      $button = $("<button partial-graft>").attr("disabled", "disabled").attr("href", "/foo").attr("refresh", "foo bar")
-      $("body").append($button)
-      $button[0].click()
-      assert.equal 0, @refreshStub.callCount, "Refresh was called when it shouldn't have been"
-
   describe 'tg-remote on links', ->
     beforeEach ->
       @Remote = stub(TurboGraft, "Remote").returns({submit: ->})
@@ -153,3 +118,43 @@ describe 'Initializers', ->
       $("body").append($link)
       $link[0].click()
       assert.equal 0, @Remote.callCount
+
+    it 'clicking on nodes inside of an <a> will bubble correctly', ->
+      $link = $("<a><i>foo</i></a>")
+        .attr("tg-remote", "PATCH")
+        .attr("refresh-on-error", "bar")
+        .attr("href", "somewhere")
+
+      $i = $link.find("i")
+
+      $("body").append($link)
+      $i[0].click()
+      assert @Remote.calledWith
+        httpRequestType: "PATCH"
+        httpUrl: "somewhere"
+        fullRefresh: false
+        refreshOnSuccess: null
+        refreshOnError: "bar"
+        refreshOnErrorExcept: null
+
+      $link.remove()
+
+    it 'clicking on nodes inside of a <button> will bubble correctly', ->
+      $link = $("<a><i><em><strong>foo</strong></em></i></a>")
+        .attr("tg-remote", "PATCH")
+        .attr("refresh-on-error", "bar")
+        .attr("href", "somewhere")
+
+      $strong = $link.find("strong")
+
+      $("body").append($link)
+      $strong[0].click()
+      assert @Remote.calledWith
+        httpRequestType: "PATCH"
+        httpUrl: "somewhere"
+        fullRefresh: false
+        refreshOnSuccess: null
+        refreshOnError: "bar"
+        refreshOnErrorExcept: null
+
+      $link.remove()


### PR DESCRIPTION
Fixes #48 (I hope)
- removes `partial-graft` since it's not very useful, and eclipsed by `tg-remote`
- properly perform `tg-remote` actions on buttons/links with DOM content inside of them

So, turns out it's pretty hard to make a delegated event elegantly in pure JS!  I think this is correct.  Didn't realize until now just how much `$(document).on(".some-selector", ->)` bought you.  Would you like to look this over?  I can add some tests after the fact (have been manually testing using the example app)

cc @kurtfunai @celsodantas @nsimmons @patrickdonovan @pushrax 
