### PR TITLE
Add tg-static, fix up refresh-always

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ Post to a remote form:
 
 Each event also is sent with a copy of the XHR, as well as a reference to the element that initated the `remote-method`.
 
+### tg-static
+
+With the `tg-static` attribute decorating a node, we can make sure that this node is not replaced during a fullpage refresh.  Contrast this to partial page refreshes, where we normally specify the set of elements that need to change.  With `tg-static`, we can define a set of elements (by annotating them with this attribute) that must never change.
+
+The internal state of any nodes marked with `tg-static` will remain, even though the entire page has been swapped out.  A partial page refresh with `onlyKeys` targeting a node inside of the `tg-static` node is also possible, persisting your static element but swapping the innards.
+
+Though, if you were to refresh the page at a higher level -- e.g., refreshing an ancestor of the `tg-static`, the static aspect is no longer obeyed and it is replaced!
+
+### refresh-always
+
+For the lazy developer in all of us, we can use the attribute `refresh-always` when, through any page refresh (partial or full) we want to be sure we've absolutely replaced a certain element, if it exists.
+
 ## Example App
 
 There is an example app that you can boot to play with TurboGraft.  Open the console and network inspector and see it in action!  This same app is also used in the TurboGraft browser testing suite.

--- a/README.md
+++ b/README.md
@@ -125,9 +125,14 @@ The internal state of any nodes marked with `tg-static` will remain, even though
 
 Though, if you were to refresh the page at a higher level -- e.g., refreshing an ancestor of the `tg-static`, the static aspect is no longer obeyed and it is replaced!
 
+Examples of where this may be useful include:
+
+- running `<video>` or `<audio>` element
+- a client-controlled static nav
+
 ### refresh-always
 
-For the lazy developer in all of us, we can use the attribute `refresh-always` when, through any page refresh (partial or full) we want to be sure we've absolutely replaced a certain element, if it exists.
+For the lazy developer in all of us, we can use the attribute `refresh-always` when we want to be sure we've absolutely replaced a certain element, if it exists.  An example of such a node you may want to apply this might be an unread notification count -- always being sure to update it if it exists in the response.
 
 ## Example App
 

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -189,7 +189,7 @@ class window.Turbolinks
 
     for existingNode in allNodesToKeep
       unless nodeId = existingNode.getAttribute('id')
-        throw new Error("TurboGraft static elements must an id.")
+        throw new Error("TurboGraft refresh: Static elements must have an id.")
 
       remoteNode = body.querySelector("##{ nodeId }")
       remoteNode.parentNode.replaceChild(existingNode, remoteNode)
@@ -203,7 +203,7 @@ class window.Turbolinks
 
     for existingNode in allNodesToKeep
       unless nodeId = existingNode.getAttribute('id')
-        throw new Error "Turbolinks refresh: Refresh key elements must have an id."
+        throw new Error "Turbolinks refresh: Refresh except key elements must have an id."
 
       remoteNode = body.querySelector("##{ nodeId }")
       remoteNode.parentNode.replaceChild(existingNode, remoteNode)

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -195,9 +195,8 @@ class window.Turbolinks
       unless nodeId = existingNode.getAttribute('id')
         throw new Error("TurboGraft refresh: Kept nodes must have an id.")
 
-      remoteNode = body.querySelector("##{ nodeId }")
-      continue unless remoteNode
-      remoteNode.parentNode.replaceChild(existingNode, remoteNode)
+      if remoteNode = body.querySelector("##{ nodeId }")
+        remoteNode.parentNode.replaceChild(existingNode, remoteNode)
 
   persistStaticElements = (body) ->
     allNodesToKeep = []

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -104,6 +104,7 @@ class window.Turbolinks
   @loadPage: (url, xhr, partialReplace = false, onLoadFunction = (->), replaceContents = [], replaceAllExcept = []) ->
     triggerEvent 'page:receive'
 
+
     if doc = processResponse(xhr, partialReplace)
       reflectNewUrl url
       nodes = changePage(extractTitleAndBody(doc)..., partialReplace, replaceContents, replaceAllExcept)
@@ -117,9 +118,11 @@ class window.Turbolinks
 
   changePage = (title, body, csrfToken, runScripts, partialReplace, replaceContents = [], replaceAllExcept = []) ->
     document.title = title if title
+
     if replaceContents.length
       return refreshNodesWithKeys(replaceContents, body)
     else
+      persistStaticElements(body)
       if replaceAllExcept.length
         refreshAllExceptWithKeys(replaceAllExcept, body)
       else
@@ -176,6 +179,20 @@ class window.Turbolinks
         existingNode.parentNode.removeChild(existingNode)
 
     refreshedNodes
+
+  persistStaticElements = (body) ->
+    allNodesToKeep = []
+
+    nodes = document.querySelectorAll("[tg-static]")
+    for node in nodes
+      allNodesToKeep.push(node)
+
+    for existingNode in allNodesToKeep
+      unless nodeId = existingNode.getAttribute('id')
+        throw new Error("TurboGraft static elements must an id.")
+
+      remoteNode = body.querySelector("##{ nodeId }")
+      remoteNode.parentNode.replaceChild(existingNode, remoteNode)
 
   refreshAllExceptWithKeys = (keys, body) ->
     allNodesToKeep = []

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -180,19 +180,24 @@ class window.Turbolinks
 
     refreshedNodes
 
+  keepNodes = (body, allNodesToKeep) ->
+    for existingNode in allNodesToKeep
+      unless nodeId = existingNode.getAttribute('id')
+        throw new Error("TurboGraft refresh: Kept nodes must have an id.")
+
+      remoteNode = body.querySelector("##{ nodeId }")
+      continue unless remoteNode
+      remoteNode.parentNode.replaceChild(existingNode, remoteNode)
+
+
   persistStaticElements = (body) ->
     allNodesToKeep = []
 
     nodes = document.querySelectorAll("[tg-static]")
-    for node in nodes
-      allNodesToKeep.push(node)
+    allNodesToKeep.push(node) for node in nodes
 
-    for existingNode in allNodesToKeep
-      unless nodeId = existingNode.getAttribute('id')
-        throw new Error("TurboGraft refresh: Static elements must have an id.")
-
-      remoteNode = body.querySelector("##{ nodeId }")
-      remoteNode.parentNode.replaceChild(existingNode, remoteNode)
+    keepNodes(body, allNodesToKeep)
+    return
 
   refreshAllExceptWithKeys = (keys, body) ->
     allNodesToKeep = []
@@ -201,12 +206,8 @@ class window.Turbolinks
       for node in document.querySelectorAll("[refresh=#{key}]")
         allNodesToKeep.push(node)
 
-    for existingNode in allNodesToKeep
-      unless nodeId = existingNode.getAttribute('id')
-        throw new Error "Turbolinks refresh: Refresh except key elements must have an id."
-
-      remoteNode = body.querySelector("##{ nodeId }")
-      remoteNode.parentNode.replaceChild(existingNode, remoteNode)
+    keepNodes(body, allNodesToKeep)
+    return
 
   executeScriptTags = ->
     scripts = Array::slice.call document.body.querySelectorAll 'script:not([data-turbolinks-eval="false"])'

--- a/test/browser/full_page_refresh_test.rb
+++ b/test/browser/full_page_refresh_test.rb
@@ -56,7 +56,17 @@ class FullPageRefreshTest < ActionDispatch::IntegrationTest
     page.fill_in 'badgeinput', :with => 'tg-static innards'
     click_link "Perform a full page refresh"
     assert_equal "tg-static innards", find_field("badgeinput").value
-    click_link "Perform a partial page refresh and refresh the navigation"
+    click_link "Perform a partial page refresh and refresh the navigation section"
     assert_equal "", find_field("badgeinput").value
+  end
+
+  test "always-refresh will always refresh the annotated nodes, regardless of refresh type" do
+    page.fill_in 'badgeinput2', :with => 'some innards'
+    click_link "Perform a full page refresh"
+    assert_equal "", find_field("badgeinput2").value
+
+    page.fill_in 'badgeinput2', :with => 'some innards'
+    click_link "Perform a partial page refresh and refresh the navigation section"
+    assert_equal "", find_field("badgeinput2").value
   end
 end

--- a/test/browser/full_page_refresh_test.rb
+++ b/test/browser/full_page_refresh_test.rb
@@ -52,7 +52,7 @@ class FullPageRefreshTest < ActionDispatch::IntegrationTest
     assert_equal "Sample Turbograft Application", page.title
   end
 
-  test "tg-static preserves client-side state of innards on partial refresh, and replaces contents on full refresh" do
+  test "tg-static preserves client-side state of innards on full refresh, but will replaces contents if we specifically partially-refresh a section inside of it" do
     page.fill_in 'badgeinput', :with => 'tg-static innards'
     click_link "Perform a full page refresh"
     assert_equal "tg-static innards", find_field("badgeinput").value

--- a/test/browser/full_page_refresh_test.rb
+++ b/test/browser/full_page_refresh_test.rb
@@ -51,4 +51,12 @@ class FullPageRefreshTest < ActionDispatch::IntegrationTest
     page.evaluate_script('window.history.back()')
     assert_equal "Sample Turbograft Application", page.title
   end
+
+  test "tg-static preserves client-side state of innards on partial refresh, and replaces contents on full refresh" do
+    page.fill_in 'badgeinput', :with => 'tg-static innards'
+    click_link "Perform a full page refresh"
+    assert_equal "tg-static innards", find_field("badgeinput").value
+    click_link "Perform a partial page refresh and refresh the navigation"
+    assert_equal "", find_field("badgeinput").value
+  end
 end

--- a/test/example/app/views/pages/show.html.erb
+++ b/test/example/app/views/pages/show.html.erb
@@ -25,7 +25,8 @@
 <div class="prepend-pre">
 <nav id="static" tg-static>
   <ul>
-    <li>Search <i id='badge1' refresh='navigation'><input type="text" name="badgeinput"></i></li>
+    <li>Navigation <i id='badge1' refresh='navigation'><input type="text" name="badgeinput"></i></li>
+    <li>Always Refresh: <i id="badge2" refresh-always><input type="text" name="badgeinput2"></i></li>
     <li>Home</li>
   </ul>
 </nav>
@@ -33,7 +34,7 @@
 
 <div class="prepend-pre">
 <%= link_to "Perform a full page refresh", page_path(@next_id) %><br>
-<%= link_to "Perform a partial page refresh and refresh the navigation", redirect_to_somewhere_else_after_POST_pages_path, "tg-remote" => "POST", "refresh-on-success" => "navigation" %>
+<%= link_to "Perform a partial page refresh and refresh the navigation section", redirect_to_somewhere_else_after_POST_pages_path, "tg-remote" => "POST", "refresh-on-success" => "navigation" %>
 </div>
 
 </section>

--- a/test/example/app/views/pages/show.html.erb
+++ b/test/example/app/views/pages/show.html.erb
@@ -25,7 +25,7 @@
 <div class="prepend-pre">
 <nav id="static" tg-static>
   <ul>
-    <li>Search <i id='badge1' refresh='navigation'><input type="text"></i></li>
+    <li>Search <i id='badge1' refresh='navigation'><input type="text" name="badgeinput"></i></li>
     <li>Home</li>
   </ul>
 </nav>

--- a/test/example/app/views/pages/show.html.erb
+++ b/test/example/app/views/pages/show.html.erb
@@ -17,6 +17,28 @@
 <% end %>
 
 <section>
+  <h1>Static Elements</h1>
+  <p>With the <code>tg-static</code> attribute decorating a node, we can make sure that this node is not replaced during a fullpage refresh.</p>
+  <p>In the example below, we demonstrate a fullpage refresh where the contents of the input will remain even though the entire page has been swapped out.  We also demonstrate a partial page refresh which swaps out specifically the input element.  Thus, we can still replace elements inside of a <code>tg-static</code> node.</p>
+  <p>Though, if were to refresh the page at a higher level -- e.g., refreshing an ancestor of the <code>tg-static</code>, the static aspect is no longer obeyed and it is replaced.</p>
+
+<div class="prepend-pre">
+<nav id="static" tg-static>
+  <ul>
+    <li>Search <i id='badge1' refresh='navigation'><input type="text"></i></li>
+    <li>Home</li>
+  </ul>
+</nav>
+</div>
+
+<div class="prepend-pre">
+<%= link_to "Perform a full page refresh", page_path(@next_id) %><br>
+<%= link_to "Perform a partial page refresh and refresh the navigation", redirect_to_somewhere_else_after_POST_pages_path, "tg-remote" => "POST", "refresh-on-success" => "navigation" %>
+</div>
+
+</section>
+
+<section>
   <h1>Partial page refresh</h1>
 
   <p>Here's a fieldset, vaguely representing some client state.  Enter some values.</p>

--- a/test/example/app/views/pages/show.html.erb
+++ b/test/example/app/views/pages/show.html.erb
@@ -20,7 +20,7 @@
   <h1>Static Elements</h1>
   <p>With the <code>tg-static</code> attribute decorating a node, we can make sure that this node is not replaced during a fullpage refresh.</p>
   <p>In the example below, we demonstrate a fullpage refresh where the contents of the input will remain even though the entire page has been swapped out.  We also demonstrate a partial page refresh which swaps out specifically the input element.  Thus, we can still replace elements inside of a <code>tg-static</code> node.</p>
-  <p>Though, if were to refresh the page at a higher level -- e.g., refreshing an ancestor of the <code>tg-static</code>, the static aspect is no longer obeyed and it is replaced.</p>
+  <p>Though, if you were to refresh the page at a higher level -- e.g., refreshing an ancestor of the <code>tg-static</code>, the static aspect is no longer obeyed and it is replaced.</p>
 
 <div class="prepend-pre">
 <nav id="static" tg-static>


### PR DESCRIPTION
Fixes https://github.com/Shopify/turbograft/issues/31

With the `tg-static` attribute decorating a node, we can make sure that this node is not replaced during a fullpage refresh.

Though, if you were to refresh the page at a higher level -- e.g., refreshing an ancestor of the tg-static, the static aspect is no longer obeyed and it is replaced.

I also fixed up `refresh-always` key to literally always refresh the node annotated.  Currently, it was refreshing only if you did a `Page.refresh(onlyKeys: [...])` with some keys, which is pretty bad naming for something called `refresh-always` lol

Potential TODO:
- in another PR, migrate `refresh-always` to `tg-always` or something like that?

cc @tmlayton @alexaitken: the feature we need for a static navigation
cc @tylermercier @celsodantas @nsimmons @patrickdonovan @kurtfunai for thoughts and input on adding a new feature to TurboGraft