### PR TITLE
guard parentNode being null when walking DOM

### DIFF
--- a/lib/assets/javascripts/turbograft/initializers.coffee
+++ b/lib/assets/javascripts/turbograft/initializers.coffee
@@ -50,9 +50,8 @@ TurboGraft.handlers.remoteFormHandler = (ev) ->
 documentListenerForButtons = (eventType, handler, useCapture = false) ->
   document.addEventListener eventType, (ev) ->
     target = ev.target
-    return if !target
 
-    while target != document && (typeof target != "undefined")
+    while target != document && (typeof target != "undefined") && (target != null)
       if target.nodeName == "A" || target.nodeName == "BUTTON"
         isNodeDisabled = nodeIsDisabled(target)
         ev.preventDefault() if isNodeDisabled

--- a/lib/assets/javascripts/turbograft/initializers.coffee
+++ b/lib/assets/javascripts/turbograft/initializers.coffee
@@ -51,7 +51,7 @@ documentListenerForButtons = (eventType, handler, useCapture = false) ->
   document.addEventListener eventType, (ev) ->
     target = ev.target
 
-    while target != document && (typeof target != "undefined") && (target != null)
+    while target != document && target?
       if target.nodeName == "A" || target.nodeName == "BUTTON"
         isNodeDisabled = nodeIsDisabled(target)
         ev.preventDefault() if isNodeDisabled


### PR DESCRIPTION
While walking the DOM it is possible that parentNode can become null. As a result, the not null check at line 53 may not guard against all null cases. This can be fixed by moving the check into the while loop conditions.

@tylermercier @celsodantas @nsimmons @patrickdonovan @kurtfunai @qq99 