### PR TITLE
don't set session if redirected not set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: ruby
 rvm:
-  - "2.0.0"
+  - '2.0.0'
+  - '2.1.2'
+  - '2.2.0'
 before_script:
   - sh -e /etc/init.d/xvfb start
   - bundle install
 env:
-  - DISPLAY=":99.0"
+  - DISPLAY=':99.0' RAILS_VERSION='3.2.0'
+  - DISPLAY=':99.0'  RAILS_VERSION='4.1.0'
+  - DISPLAY=':99.0'  RAILS_VERSION='4.2.0'
 script: bundle exec rake ci

--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -20,6 +20,7 @@ class TurboGraft.Remote
     xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
     xhr.setRequestHeader('Accept', 'text/html, application/xhtml+xml, application/xml')
     xhr.setRequestHeader("Content-Type", @contentType) if @contentType
+    xhr.setRequestHeader 'X-XHR-Referer', document.location.href
 
     csrfToken = CSRFToken.get().token
     xhr.setRequestHeader('X-CSRF-Token', csrfToken) if csrfToken

--- a/test/controller/pages_controller_test.rb
+++ b/test/controller/pages_controller_test.rb
@@ -26,6 +26,12 @@ class PagesControllerTest < ActionController::TestCase
     assert_equal "http://test.host/pages/1", session[:_turbolinks_redirect_to]
   end
 
+  test "_compute_redirect_to_location sets redirect_to for turbolinks only if request referrer is set" do
+    get :index
+    assert_response :ok
+    assert_nil session[:_turbolinks_redirect_to]
+  end
+
   test "set_xhr_redirected_to sets X-XHR-Redirected-To" do
     get :index, {}, {_turbolinks_redirect_to: 'http://test.host/expected'}
     assert_response :ok

--- a/test/example/app/views/pages/show.html.erb
+++ b/test/example/app/views/pages/show.html.erb
@@ -111,7 +111,10 @@
     operation = $.ajax({
       type: "POST",
       url: "<%= redirect_to_somewhere_else_after_POST_pages_path %>",
-      data: {}
+      data: {},
+      beforeSend: function (request) {
+        request.setRequestHeader("X-XHR-Referer", document.location.href);
+      }
     });
 
     operation.done(function(results, status, xhr) {


### PR DESCRIPTION
@Thibaut @qq99 

##### Problem 

I found an issue in our usage of this where redirecting on location.replace would set `session[:_turbolinks_redirect_to]` without headers. This would cause subsequent requests to get redirected when they shouldn't

https://github.com/Shopify/shopify/issues/35973#issuecomment-69338390

##### Solution

Update to latest version of `xhr_headers`: https://github.com/rails/turbolinks/blob/b7553314d82f9907ea6da57361bb4fe9e956eaf6/lib/turbolinks/xhr_headers.rb#L28. I followed the history of xhr_headers, and all changes seem reasonable. 

I have yet to double check this fixes my actual problem :).