### PR TITLE
Fixed a bug with `page:load` event not having proper event.data

### DIFF
--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -119,9 +119,11 @@ class window.Turbolinks
   changePage = (title, body, csrfToken, runScripts, partialReplace, onlyKeys = [], exceptKeys = []) ->
     document.title = title if title
 
-    refreshRefreshAlwaysNodes(body)
+    refreshedNodes = []
+    refreshedNodes = refreshRefreshAlwaysNodes(body)
     if onlyKeys.length
-      return refreshNodesWithKeys(onlyKeys, body)
+      refreshedNodes = refreshedNodes.concat refreshNodesWithKeys(onlyKeys, body)
+      return refreshedNodes
     else
       persistStaticElements(body)
       if exceptKeys.length
@@ -178,8 +180,7 @@ class window.Turbolinks
     for node in document.querySelectorAll("[refresh-always]")
       allNodesToBeRefreshed.push(node)
 
-    refreshNodes(allNodesToBeRefreshed, body)
-    return
+    return refreshNodes(allNodesToBeRefreshed, body)
 
   refreshNodesWithKeys = (keys, body) ->
     allNodesToBeRefreshed = []
@@ -187,8 +188,7 @@ class window.Turbolinks
       for node in document.querySelectorAll("[refresh=#{key}]")
         allNodesToBeRefreshed.push(node)
 
-    refreshNodes(allNodesToBeRefreshed, body)
-    return
+    return refreshNodes(allNodesToBeRefreshed, body)
 
   keepNodes = (body, allNodesToKeep) ->
     for existingNode in allNodesToKeep

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -112,3 +112,21 @@ describe 'Turbolinks', ->
         Turbolinks.visit "/some_request", true, ['turbo-area']
         @server.respond()
         assert.equal 0, globalStub.callCount
+
+      it 'triggers the page:load event with a list of nodes that are new (freshly replaced)', ->
+        $(document).one 'page:load', (event) ->
+          ev = event.originalEvent
+          assert.equal true, ev.data instanceof Array
+          assert.equal 1, ev.data.length
+          node = ev.data[0]
+
+          assert.equal "turbo-area", node.id
+          assert.equal "turbo-area", node.getAttribute('refresh')
+
+        @server.respondWith([200, { "Content-Type": "text/html" }, html_one]);
+
+        Turbolinks.visit "/some_request", true, ['turbo-area']
+        @server.respond()
+
+        $(document).off 'page:load'
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ require 'rails/test_help'
 
 Capybara.app = Example::Application
 Capybara.current_driver = :selenium
-Capybara.default_wait_time = 5
+Capybara.default_wait_time = 7
 
 Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new(color: true))
 


### PR DESCRIPTION
cc @karlhungus 

Bug:

Listening to the TurboGraft emitted event `page:load`, as of `0.1.5`, does not have a list of new nodes in `event.data` as it should have

Explanation:

- `refreshNodes: ->` returns a list of nodes that were refreshed
- When I refactored `refreshNodesWithKeys: ->` into 2 separate fns, `refreshRefreshAlwaysNodes: ->` and `refreshNodesWithKeys: ->` (it previously did both of these in 1 function), I forgot to return `refreshedNodes` properly
- `changePage` returns a list of refreshed nodes or void, and this event is fired:  `triggerEvent 'page:load', nodes`
- ^ previously, `nodes` in the event triggered above was always `null`, now it is something!

Effect:

If you had a listener for `page:load` in your app and were expecting to see a list of nodes you would never see any nodes.  Say, you were using `Twine.refresh(newNodes)`, you would essentially never refresh the new nodes!