### PR TITLE
Prevent refresh-always from destroying nodes

### DIFF
--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -163,6 +163,7 @@ class window.Turbolinks
         throw new Error "Turbolinks refresh: Refresh key elements must have an id."
 
       if newNode = body.querySelector("##{ nodeId }")
+        newNode = newNode.cloneNode(true)
         existingNode.parentNode.replaceChild(newNode, existingNode)
 
         if newNode.nodeName == 'SCRIPT' && newNode.getAttribute("data-turbolinks-eval") != "false"

--- a/test/browser/full_page_refresh_test.rb
+++ b/test/browser/full_page_refresh_test.rb
@@ -18,8 +18,8 @@ class FullPageRefreshTest < ActionDispatch::IntegrationTest
     page.execute_script "document.title = 'Something';"
     page.execute_script "$('body').addClass('hot-new-bod');"
     click_link "Perform a full navigation to learn more"
+    page.assert_no_selector('body.hot-new-bod')
     assert_not_equal "Something", page.title
-    refute page.has_selector?("body.hot-new-bod")
   end
 
   test "will execute scripts that do not have data-turbolinks-eval='false'" do
@@ -40,15 +40,27 @@ class FullPageRefreshTest < ActionDispatch::IntegrationTest
 
   test "going to a URL that will error 500, and hitting the browser back button, we see the correct page (and not the 500)" do
     click_link "I will throw an error 500"
+    has_text = false
+    while !has_text
+      has_text = page.assert_text('Error 500!')
+      sleep 1
+    end
     assert_not_equal "Sample Turbograft Application", page.title
-    page.evaluate_script('window.history.back()')
+    page.execute_script 'window.history.back()'
+    page.assert_no_text('Error 500!')
     assert_equal "Sample Turbograft Application", page.title
   end
 
   test "going to a URL that will error 404, and hitting the browser back button, we see the correct page (and not the 404)" do
     click_link "I will throw an error 404"
+    has_text = false
+    while !has_text
+      has_text = page.assert_text('Error 404!')
+      sleep 1
+    end
     assert_not_equal "Sample Turbograft Application", page.title
-    page.evaluate_script('window.history.back()')
+    page.execute_script 'window.history.back()'
+    page.assert_no_text('Error 404!')
     assert_equal "Sample Turbograft Application", page.title
   end
 
@@ -60,13 +72,22 @@ class FullPageRefreshTest < ActionDispatch::IntegrationTest
     assert_equal "", find_field("badgeinput").value
   end
 
-  test "always-refresh will always refresh the annotated nodes, regardless of refresh type" do
-    page.fill_in 'badgeinput2', :with => 'some innards'
+  test "refresh-always will always refresh the annotated nodes, regardless of refresh type" do
+    page.fill_in 'badgeinput2', :with => 'some innards 523'
     click_link "Perform a full page refresh"
+    page.assert_no_text "some innards 523"
     assert_equal "", find_field("badgeinput2").value
-
-    page.fill_in 'badgeinput2', :with => 'some innards'
+    page.fill_in 'badgeinput2', :with => 'some innards 555'
     click_link "Perform a partial page refresh and refresh the navigation section"
+    page.assert_no_text "some innards 555"
     assert_equal "", find_field("badgeinput2").value
+  end
+
+  test "refresh-always will not destroy or remove the node on a full page refresh" do
+    assert page.has_content?('refresh-always outside of tg-static')
+    assert page.has_content?("You're on page 1")
+    click_link 'next'
+    assert page.has_content?("You're on page 2")
+    assert page.has_content?('refresh-always outside of tg-static')
   end
 end

--- a/test/example/app/views/pages/show.html.erb
+++ b/test/example/app/views/pages/show.html.erb
@@ -30,6 +30,7 @@
     <li>Home</li>
   </ul>
 </nav>
+<div id="refresh-always-section" refresh-always>refresh-always outside of tg-static: <%= rand(1000) %></div>
 </div>
 
 <div class="prepend-pre">

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ require 'rails/test_help'
 
 Capybara.app = Example::Application
 Capybara.current_driver = :selenium
-Capybara.default_wait_time = 7
+Capybara.default_wait_time = 2
 
 Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new(color: true))
 


### PR DESCRIPTION
When replacing nodes, it seems like `existingNode.parentNode.replaceChild(newNode, existingNode);` will move `newNode` out of any current tree its in, and into the tree where `existingNode` used to sit.

`0.1.5` made `refresh-always` call way more often, not just if there were `onlyKeys` to refresh.  Thus, this line of code was being run & and any `existingNode` that had `refresh-always` on it was being moved from the server-fresh `body` and being placed into `document.body`.  But!-- since it's a full page refresh, the next step is replacing `document.body` with server-fresh `body`, which now lacks this node, leading to the appearance of the `refresh-always` nodes disappearing.

The solution I suggest is to make a deep clone of the node when replacing.

cc @karlhungus @patrickdonovan @tylermercier @kurtfunai 

Crazy enough, we didn't catch this in our example app because the only `refresh-always` node was inside a `tg-static` node, which masked its disappearance on a full refresh :(  I've added an example to the app now and a test against it

This will become `v0.1.8`

Related: https://github.com/Shopify/shopify/pull/36344