### PR TITLE
Don't automatically add _method to FormData

### DIFF
--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -58,9 +58,7 @@ class TurboGraft.Remote
     else
       formData = ''
 
-    if formData instanceof FormData
-      formData.append("_method", @opts.httpRequestType) if @opts.httpRequestType
-    else
+    if formData not instanceof FormData
       @contentType = "application/x-www-form-urlencoded; charset=UTF-8"
       formData = @formAppend(formData, "_method", @opts.httpRequestType) if formData.indexOf("_method") == -1 && @opts.httpRequestType && @actualRequestType != 'GET'
 

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -371,6 +371,26 @@ describe 'Remote', ->
       remote = new TurboGraft.Remote({httpRequestType: 'DELETE'}, form) # DELETE should be ignored here
       assert.equal "_method=PATCH", remote.formData
 
+    it 'will not set _method when using FormData', ->
+      form = $("<form><input type='file' name='foo'></form>")[0]
+
+      oldFormData = window.FormData
+
+      constructed = false
+      window.FormData = class FormData
+        constructor: ->
+          constructed = true
+          @hash = {}
+
+        append: (key, val) ->
+          @hash[key] = val
+
+      remote = new TurboGraft.Remote({httpRequestType: 'DELETE'}, form)
+      assert.equal undefined, remote.formData.hash._method
+      assert.isTrue constructed
+
+      window.FormData = oldFormData
+
     it 'will not add a _method if improperly supplied', ->
       form = $("<form method='POST'></form>")[0]
 


### PR DESCRIPTION
This will let us properly https://github.com/Shopify/shopify/issues/36350

We can't set `tg-remote` on the products form because the form's `method="POST"` attribute that rails is setting overwrites the `method="PATCH"` hidden field within the form. We should just not set the submission type based on form attributes, and instead use a `_method` hidden field. Ideally we'd look at what's already in `formData` but we can't because FormData is stored in native code and we don't have access.

@qq99 @celsodantas 
