### PR TITLE
fixing autofocus for fullpage refresh

### DIFF
--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -104,7 +104,6 @@ class window.Turbolinks
   @loadPage: (url, xhr, partialReplace = false, onLoadFunction = (->), replaceContents = [], replaceAllExcept = []) ->
     triggerEvent 'page:receive'
 
-
     if doc = processResponse(xhr, partialReplace)
       reflectNewUrl url
       nodes = changePage(extractTitleAndBody(doc)..., partialReplace, replaceContents, replaceAllExcept)
@@ -133,6 +132,7 @@ class window.Turbolinks
       triggerEvent 'page:before-replace'
       document.documentElement.replaceChild body, document.body
       CSRFToken.update csrfToken if csrfToken?
+      setAutofocusElement()
       executeScriptTags() if runScripts
       currentState = window.history.state
       triggerEvent 'page:change'
@@ -154,6 +154,11 @@ class window.Turbolinks
       matchingNodes.push(node)
 
     return matchingNodes
+
+  setAutofocusElement = ->
+    autofocusElement = (list = document.querySelectorAll 'input[autofocus], textarea[autofocus]')[list.length - 1]
+    if autofocusElement and document.activeElement isnt autofocusElement
+      autofocusElement.focus()
 
   deleteRefreshNeverNodes = (body) ->
     for node in body.querySelectorAll('[refresh-never]')

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -120,7 +120,9 @@ class window.Turbolinks
 
     if onlyKeys.length
       nodesToRefresh = [].concat(getNodesWithRefreshAlways(), getNodesMatchingRefreshKeys(onlyKeys))
-      return refreshNodes(nodesToRefresh, body)
+      nodes = refreshNodes(nodesToRefresh, body)
+      setAutofocusElement() if anyAutofocusElement(nodes)
+      return nodes
     else
       refreshNodes(getNodesWithRefreshAlways(), body)
       persistStaticElements(body)
@@ -154,6 +156,13 @@ class window.Turbolinks
       matchingNodes.push(node)
 
     return matchingNodes
+
+  anyAutofocusElement = (nodes) ->
+    for node in nodes
+      if node.querySelectorAll('input[autofocus], textarea[autofocus]').length > 0
+        return true
+
+    false
 
   setAutofocusElement = ->
     autofocusElement = (list = document.querySelectorAll 'input[autofocus], textarea[autofocus]')[list.length - 1]


### PR DESCRIPTION
## Problem

When we refresh the page using turbograft, `autofocus` does not work, only works if you refresh the page.

This was fixed in Turbolinks a while ago, but the fix happened after we branched from it.

## Solution

I'm just copying the same solution from Turbolinks: https://github.com/rails/turbolinks/commit/3aab7249bb0b695b49f2a31493653f0dce87729c
The comment on Turbolinks that the problem is only happening on Firefox is wrong. It also happens on other browsers as well.

I'm focusing only on `fullpage` refresh. The reason is because I don't see any use case to also do that on partial page refresh.

reviews @kurtfunai @qq99 @karlhungus  @patrickdonovan
