### PR TITLE
Avoid returning stale nodes by doing replace in one shot, as it was performed previously

### DIFF
--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -119,12 +119,11 @@ class window.Turbolinks
   changePage = (title, body, csrfToken, runScripts, partialReplace, onlyKeys = [], exceptKeys = []) ->
     document.title = title if title
 
-    refreshedNodes = []
-    refreshedNodes = refreshRefreshAlwaysNodes(body)
     if onlyKeys.length
-      refreshedNodes = refreshedNodes.concat refreshNodesWithKeys(onlyKeys, body)
-      return refreshedNodes
+      nodesToRefresh = [].concat(getNodesWithRefreshAlways(), getNodesMatchingRefreshKeys(onlyKeys))
+      return refreshNodes(nodesToRefresh, body)
     else
+      refreshNodes(getNodesWithRefreshAlways(), body)
       persistStaticElements(body)
       if exceptKeys.length
         refreshAllExceptWithKeys(exceptKeys, body)
@@ -140,6 +139,21 @@ class window.Turbolinks
       triggerEvent 'page:update'
 
     return
+
+  getNodesMatchingRefreshKeys = (keys) ->
+    matchingNodes = []
+    for key in keys
+      for node in document.querySelectorAll("[refresh=#{key}]")
+        matchingNodes.push(node)
+
+    return matchingNodes
+
+  getNodesWithRefreshAlways = ->
+    matchingNodes = []
+    for node in document.querySelectorAll("[refresh-always]")
+      matchingNodes.push(node)
+
+    return matchingNodes
 
   deleteRefreshNeverNodes = (body) ->
     for node in body.querySelectorAll('[refresh-never]')
@@ -175,21 +189,6 @@ class window.Turbolinks
         existingNode.parentNode.removeChild(existingNode)
 
     refreshedNodes
-
-  refreshRefreshAlwaysNodes = (body) ->
-    allNodesToBeRefreshed = []
-    for node in document.querySelectorAll("[refresh-always]")
-      allNodesToBeRefreshed.push(node)
-
-    return refreshNodes(allNodesToBeRefreshed, body)
-
-  refreshNodesWithKeys = (keys, body) ->
-    allNodesToBeRefreshed = []
-    for key in keys
-      for node in document.querySelectorAll("[refresh=#{key}]")
-        allNodesToBeRefreshed.push(node)
-
-    return refreshNodes(allNodesToBeRefreshed, body)
 
   keepNodes = (body, allNodesToKeep) ->
     for existingNode in allNodesToKeep

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -58,6 +58,20 @@ describe 'Turbolinks', ->
     </html>
   """
 
+  response_with_refresh_always = """
+    <!doctype html>
+    <html>
+      <head>
+        <title>Hi</title>
+      </head>
+      <body>
+        <div id="div1" refresh="div1">
+          <div id="div2" refresh-always>Refresh-always</div>
+        </div>
+      </body>
+    </html>
+  """
+
   it 'is defined', ->
     assert Turbolinks
 
@@ -130,3 +144,44 @@ describe 'Turbolinks', ->
 
         $(document).off 'page:load'
 
+      it 'does not trigger the page:before-partial-replace event more than once', ->
+        handler = stub()
+        $(document).on 'page:before-partial-replace', ->
+          handler()
+          assert handler.calledOnce
+
+        @server.respondWith([200, { "Content-Type": "text/html" }, html_one]);
+
+        Turbolinks.visit "/some_request", true, ['turbo-area']
+        @server.respond()
+
+        $(document).off 'page:before-partial-replace'
+
+      it.only 'replaces and passes through the outermost nodes if a series of nodes got replaced', ->
+        currentBody = """
+          <div id="div1" refresh="div1">
+            <div id="div2" refresh-always>Refresh-always</div>
+          </div>
+        """
+
+        $("body").append($(currentBody))
+
+        $(document).on 'page:before-partial-replace', (ev) ->
+          nodes = ev.originalEvent.data
+          assert.equal 2, nodes.length
+          assert.equal 'div2', nodes[0].id
+          assert.equal 'div1', nodes[1].id
+
+        $(document).on 'page:load', (ev) ->
+          nodes = ev.originalEvent.data
+          assert.equal 1, nodes.length
+          assert.equal 'div1', nodes[0].id
+
+        @server.respondWith([200, { "Content-Type": "text/html" }, response_with_refresh_always]);
+
+        Page.refresh(onlyKeys: ['div1'])
+        @server.respond()
+
+        $(document).off 'page:before-partial-replace'
+
+        $("#div1").remove()

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -157,7 +157,7 @@ describe 'Turbolinks', ->
 
         $(document).off 'page:before-partial-replace'
 
-      it.only 'replaces and passes through the outermost nodes if a series of nodes got replaced', ->
+      it 'replaces and passes through the outermost nodes if a series of nodes got replaced', ->
         currentBody = """
           <div id="div1" refresh="div1">
             <div id="div2" refresh-always>Refresh-always</div>

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -183,5 +183,6 @@ describe 'Turbolinks', ->
         @server.respond()
 
         $(document).off 'page:before-partial-replace'
+        $(document).off 'page:load'
 
         $("#div1").remove()


### PR DESCRIPTION
cc @patrickdonovan @DrewMartin @tylermercier @celsodantas @kurtfunai 

```coffee
document.addEventListener 'page:load', (event) ->
  reset(event.data)
```

This should fix the bug we saw earlier where the returned `nodes` (`event.data` in above listener) during partial-refresh had a stale node inside it.  Ie, nodes that are not even attached to the `window.body`.

An example problematic set of returned nodes from a partial-replace in `0.1.9` is:

- `foo` (a `refresh-always` node)
- `bar` (a `refresh="something"` node that is ancestor of `foo`)

`foo` is first element in array b/c of `refresh-always` processing.  Then `bar` is next because of `onlyKeys` processing.

However, since `bar` encapsulates `foo`, `foo` is stale and no longer in the DOM, but it is returned to any listeners of the event.  

`0.1.5` created this problem because it split the refreshOnSuccess strategy into 1 phase for `refreshAlways` nodes and a second phase for `refreshKeys` nodes.  The solution in this PR is to do a single refresh, but with a larger set of nodes (more akin to `<=0.1.4`).  In the case where we are not doing `onlyKeys`, we still refresh the `refresh-always` so we end up with `refresh-always` always firing (which was the intended result of `0.1.6`).

The `parentIsRefreshing` function guards against this staleness, but in order for it to work correctly, the call to `refreshNodes` must have the entire known set of nodes that are being refreshed and cannot be split into 2 calls of 2 different sets