### PR TITLE
Enable turbograft on ios chrome

### DIFF
--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -19,9 +19,6 @@ historyStateIsDefined =
 browserSupportsPushState =
   window.history and window.history.pushState and window.history.replaceState and historyStateIsDefined
 
-browserIsntBuggy =
-  !navigator.userAgent.match /CriOS\//
-
 window.triggerEvent = (name, data) ->
   event = document.createEvent 'Events'
   event.data = data if data
@@ -42,7 +39,7 @@ popCookie = (name) ->
 requestMethodIsSafe =
   popCookie('request_method') in ['GET','']
 
-browserSupportsTurbolinks = browserSupportsPushState and browserIsntBuggy and requestMethodIsSafe
+browserSupportsTurbolinks = browserSupportsPushState and requestMethodIsSafe
 
 browserSupportsCustomEvents =
   document.addEventListener and document.createEvent


### PR DESCRIPTION
Closes #62

Originally done because that's what turbolinks does (rails/turbolinks#82) but it looks like either our version of turbolinks or ios chrome doesn't suffer from this bug any more. This will fix https://github.com/Shopify/shopify/issues/29477

@qq99 @patrickdonovan @celsodantas @maartenvg 