### PR TITLE
add refresh on success except logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,14 @@ It requires your `<form>`, `<a>`, or `<button>` to be marked up with:
 * `tg-remote`: (optionally valueless for `<form>`, but requires an HTTP method for links) the HTTP method you wish to call on your endpoint
 * `href`: (if node is `<a>` or `<button>`) the URL of the endpoint you wish to hit
 * `refresh-on-success`: (optional) The refresh keys to be refreshed, using the body of the response. This is space-delimited
+* `full-refresh-on-success-except`: (optional) Replaces body except for specififed refresh keys, using the body of the XHR which has succeeded
 * `refresh-on-error`: (optional) The refresh keys to be refreshed, but using body of XHR which has failed. Only works with error 422. If the XHR returns and error and you do not supply a refresh-on-error, nothing is changed
 * `full-refresh-on-error-except`: (optional) Replaces body except for specified refresh keys, using the body of the XHR which has failed.  Only works with error 422
 * `remote-once`: (optional) The action will only be performed once. Removes `remote-method` and `remote-once` from element after consumption
 * `full-refresh`: Rather than using the content of the XHR response for partial page replacement, a full page refresh is performed. If `refresh-on-success` is defined, the page will be reloaded on these keys. If `refresh-on-success` is not defined, a full page refresh is performed. Defaults to true if neither refresh-on-success nor refresh-on-error are provided
 * `tg-remote-norefresh`: Prevents `Page.refresh()` from being called, allowing methods to be executed without updating client state
+
+Note that as `refresh-on-*` pertains to partial refreshes and `full-refresh-on-*-except` pertains to full refreshes, they are incompatible with each other and should not be combined.
 
 ### Examples
 

--- a/lib/assets/javascripts/turbograft/initializers.coffee
+++ b/lib/assets/javascripts/turbograft/initializers.coffee
@@ -21,6 +21,7 @@ TurboGraft.handlers.remoteMethodHandler = (ev) ->
     httpUrl: httpUrl
     fullRefresh: target.getAttribute('full-refresh')?
     refreshOnSuccess: target.getAttribute('refresh-on-success')
+    refreshOnSuccessExcept: target.getAttribute('full-refresh-on-success-except')
     refreshOnError: target.getAttribute('refresh-on-error')
     refreshOnErrorExcept: target.getAttribute('full-refresh-on-error-except')
 
@@ -40,6 +41,7 @@ TurboGraft.handlers.remoteFormHandler = (ev) ->
     httpUrl: httpUrl
     fullRefresh: target.getAttribute('full-refresh')?
     refreshOnSuccess: target.getAttribute('refresh-on-success')
+    refreshOnSuccessExcept: target.getAttribute('full-refresh-on-success-except')
     refreshOnError: target.getAttribute('refresh-on-error')
     refreshOnErrorExcept: target.getAttribute('full-refresh-on-error-except')
 

--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -8,6 +8,7 @@ class TurboGraft.Remote
     @formData = @createPayload(form)
 
     @refreshOnSuccess       = @opts.refreshOnSuccess.split(" ")       if @opts.refreshOnSuccess
+    @refreshOnSuccessExcept = @opts.refreshOnSuccessExcept.split(" ") if @opts.refreshOnSuccessExcept
     @refreshOnError         = @opts.refreshOnError.split(" ")         if @opts.refreshOnError
     @refreshOnErrorExcept   = @opts.refreshOnErrorExcept.split(" ")   if @opts.refreshOnErrorExcept
 
@@ -102,6 +103,10 @@ class TurboGraft.Remote
         Page.refresh
           response: xhr
           onlyKeys: @refreshOnSuccess
+      else if @refreshOnSuccessExcept
+        Page.refresh
+          response: xhr
+          exceptKeys: @refreshOnSuccessExcept
       else
         Page.refresh
           response: xhr
@@ -114,10 +119,13 @@ class TurboGraft.Remote
       initiator: @initiator
       xhr: xhr
 
-    if @refreshOnError || @refreshOnErrorExcept
+    if @refreshOnError
       Page.refresh
         response: xhr
         onlyKeys: @refreshOnError
+    else if @refreshOnErrorExcept
+      Page.refresh
+        response: xhr
         exceptKeys: @refreshOnErrorExcept
     else
       triggerEventFor 'turbograft:remote:fail:unhandled', @initiator,

--- a/test/browser/partial_page_refresh_test.rb
+++ b/test/browser/partial_page_refresh_test.rb
@@ -70,6 +70,20 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     assert_equal new_location, old_location
   end
 
+  test "tg-remote on a link with GET and full-refresh-on-success-except and status 200" do
+    random_a = find('#random-number-a').text
+
+    assert page.has_content?("page 1")
+    old_location = current_url
+
+    click_link "tg-remote GET to response of 200 with full-refresh-on-success-except"
+
+    new_location = current_url
+    refute page.has_content?("Page 1")
+    assert_equal random_a, find('#random-number-a').text
+    assert_equal new_location, old_location
+  end
+
   test "tg-remote on a link with GET and refresh-on-error and status 422" do
     assert page.has_content?("page 1")
     old_location = current_url

--- a/test/example/app/views/pages/show.html.erb
+++ b/test/example/app/views/pages/show.html.erb
@@ -185,6 +185,12 @@
 </div>
 
 <div class="prepend-pre">
+<a href="<%= page_path(rand(100)) %>" tg-remote="GET" full-refresh-on-success-except="section-a">
+  <i>tg-remote GET to response of 200 with full-refresh-on-success-except</i>
+</a>
+</div>
+
+<div class="prepend-pre">
 <a href="<%= error_422_pages_path %>" tg-remote="GET" refresh-on-error="page">tg-remote GET to response of 422</a>
 </div>
 

--- a/test/javascripts/initializers_test.coffee
+++ b/test/javascripts/initializers_test.coffee
@@ -15,6 +15,7 @@ describe 'Initializers', ->
         .attr("refresh-on-success", "foo")
         .attr("refresh-on-error", "bar")
         .attr("full-refresh-on-error-except", "zar")
+        .attr("full-refresh-on-success-except", "zap")
         .attr("action", "somewhere")
       $form.append("<input type='submit'>")
 
@@ -27,6 +28,7 @@ describe 'Initializers', ->
         httpUrl: "somewhere"
         fullRefresh: false
         refreshOnSuccess: "foo"
+        refreshOnSuccessExcept: "zap"
         refreshOnError: "bar"
         refreshOnErrorExcept: "zar"
 
@@ -45,6 +47,7 @@ describe 'Initializers', ->
         .attr("refresh-on-success", "foo")
         .attr("refresh-on-error", "bar")
         .attr("full-refresh-on-error-except", "zar")
+        .attr("full-refresh-on-success-except", "zap")
         .attr("href", "somewhere")
 
       $("body").append($link)
@@ -55,6 +58,7 @@ describe 'Initializers', ->
         httpUrl: "somewhere"
         fullRefresh: false
         refreshOnSuccess: "foo"
+        refreshOnSuccessExcept: "zap"
         refreshOnError: "bar"
         refreshOnErrorExcept: "zar"
 
@@ -72,6 +76,7 @@ describe 'Initializers', ->
         httpUrl: "somewhere"
         fullRefresh: false
         refreshOnSuccess: null
+        refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
 
@@ -89,6 +94,7 @@ describe 'Initializers', ->
         httpUrl: "somewhere"
         fullRefresh: false
         refreshOnSuccess: null
+        refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
 
@@ -106,6 +112,7 @@ describe 'Initializers', ->
         httpUrl: "somewhere"
         fullRefresh: false
         refreshOnSuccess: "foo"
+        refreshOnSuccessExcept: null
         refreshOnError: null
         refreshOnErrorExcept: null
 
@@ -123,8 +130,27 @@ describe 'Initializers', ->
         httpUrl: "somewhere"
         fullRefresh: false
         refreshOnSuccess: null
+        refreshOnSuccessExcept: null
         refreshOnError: null
         refreshOnErrorExcept: 'zew'
+
+    it 'respects full-refresh-on-success-except', ->
+      $link = $("<a>")
+        .attr("tg-remote", "GET")
+        .attr("full-refresh-on-success-except", "zew")
+        .attr("href", "somewhere")
+
+      $("body").append($link)
+      $link[0].click()
+      assert @Remote.called
+      assert @Remote.calledWith
+        httpRequestType: "GET"
+        httpUrl: "somewhere"
+        fullRefresh: false
+        refreshOnSuccess: null
+        refreshOnSuccessExcept: 'zew'
+        refreshOnError: null
+        refreshOnErrorExcept: null
 
     it 'respects full-refresh', ->
       $link = $("<a>")
@@ -142,6 +168,7 @@ describe 'Initializers', ->
         httpUrl: "somewhere"
         fullRefresh: true
         refreshOnSuccess: "foo"
+        refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
 
@@ -173,6 +200,7 @@ describe 'Initializers', ->
         httpUrl: "somewhere"
         fullRefresh: false
         refreshOnSuccess: null
+        refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
 
@@ -194,6 +222,7 @@ describe 'Initializers', ->
         httpUrl: "somewhere"
         fullRefresh: false
         refreshOnSuccess: null
+        refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
 

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -262,6 +262,24 @@ describe 'Remote', ->
         response: sinon.match.has('responseText', '<div>Hey there</div>')
         onlyKeys: ['a', 'b', 'c']
 
+    it 'XHR=200: will trigger Page.refresh using XHR and refresh-on-success-except', ->
+      server = sinon.fakeServer.create();
+      server.respondWith("POST", "/foo/bar",
+            [200, { "Content-Type": "text/html" },
+             '<div>Hey there</div>']);
+
+      remote = new TurboGraft.Remote
+        httpRequestType: "POST"
+        httpUrl: "/foo/bar"
+        refreshOnSuccessExcept: "a b c"
+      , @initiating_target
+      remote.submit()
+
+      server.respond()
+      assert @refreshStub.calledWith
+        response: sinon.match.has('responseText', '<div>Hey there</div>')
+        exceptKeys: ['a', 'b', 'c']
+
     it 'XHR=200: will trigger Page.refresh with refresh-on-success when full-refresh is provided', ->
       server = sinon.fakeServer.create();
       server.respondWith("POST", "/foo/bar",
@@ -333,7 +351,25 @@ describe 'Remote', ->
       assert @refreshStub.calledWith
         response: sinon.match.has('responseText', '<div id="foo" refresh="foo">Error occured</div>')
         onlyKeys: ['a', 'b', 'c']
-        exceptKeys: undefined
+
+    it 'will trigger Page.refresh using XHR and refresh-on-error-except', ->
+      server = sinon.fakeServer.create();
+      server.respondWith("POST", "/foo/bar",
+            [422, { "Content-Type": "text/html" },
+             '<div id="foo" refresh="foo">Error occured</div>']);
+      remote = new TurboGraft.Remote
+        httpRequestType: "POST"
+        httpUrl: "/foo/bar"
+        refreshOnErrorExcept: "a b c"
+        fullRefresh: true
+      , @initiating_target
+      remote.submit()
+
+      server.respond()
+
+      assert @refreshStub.calledWith
+        response: sinon.match.has('responseText', '<div id="foo" refresh="foo">Error occured</div>')
+        exceptKeys: ['a', 'b', 'c']
 
     it 'will not trigger Page.refresh if no refresh-on-error is present', ->
       server = sinon.fakeServer.create();


### PR DESCRIPTION
Adding `full-refresh-on-success-except` which will allow for selectively omitting parts of the page when refreshing on success.

review @qq99 @karlhungus 