### PR TITLE
filter out inputs which do not have name attribute

### DIFF
--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -51,10 +51,13 @@ class TurboGraft.Remote
 
   createPayload: (form) ->
     if form
-      if form.querySelectorAll("[type='file']").length > 0
-        formData = new FormData(form)
+      $cleanForm = $(form).clone()
+      $cleanForm.find('input[tg-remote-noserialize]').remove()
+      cleanForm = $cleanForm[0]
+      if cleanForm.querySelectorAll("[type='file']").length > 0
+        formData = new FormData(cleanForm)
       else # for much smaller payloads
-        formData = @uriEncodeForm(form)
+        formData = @uriEncodeForm(cleanForm)
     else
       formData = ''
 

--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -52,7 +52,7 @@ class TurboGraft.Remote
   createPayload: (form) ->
     if form
       $cleanForm = $(form).clone()
-      $cleanForm.find('input[tg-remote-noserialize]').remove()
+      $cleanForm.querySelectorAll('input[tg-remote-noserialize]').remove()
       cleanForm = $cleanForm[0]
       if cleanForm.querySelectorAll("[type='file']").length > 0
         formData = new FormData(cleanForm)

--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -51,9 +51,9 @@ class TurboGraft.Remote
 
   createPayload: (form) ->
     if form
-      $cleanForm = $(form).clone()
-      $cleanForm.querySelectorAll('input[tg-remote-noserialize]').remove()
-      cleanForm = $cleanForm[0]
+      cleanForm = form.cloneNode(true)
+      for node in cleanForm.querySelectorAll('input:not([name])')
+        node.parentNode.removeChild(node)
       if cleanForm.querySelectorAll("[type='file']").length > 0
         formData = new FormData(cleanForm)
       else # for much smaller payloads

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -358,6 +358,18 @@ describe 'Remote', ->
       remote = new TurboGraft.Remote({}, form)
       assert (remote.formData instanceof FormData)
 
+    it 'will not create FormData object if the only input has tg-remote-noserialize', ->
+      form = $("<form><input tg-remote-noserialize type='file' name='foo'></form>")[0]
+
+      remote = new TurboGraft.Remote({}, form)
+      assert.isFalse (remote.formData instanceof FormData)
+
+    it 'will create FormData object but skip any input with tg-remote-noserialize', ->
+      form = $("<form><input type='file' name='foo'><input tg-remote-noserialize type='file' name='bar'></form>")[0]
+
+      remote = new TurboGraft.Remote({}, form)
+      assert (remote.formData instanceof FormData)
+
     it 'will add the _method to the form if supplied in the constructor', ->
       form = $("<form></form>")[0]
 

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -358,14 +358,14 @@ describe 'Remote', ->
       remote = new TurboGraft.Remote({}, form)
       assert (remote.formData instanceof FormData)
 
-    it 'will not create FormData object if the only input has tg-remote-noserialize', ->
-      form = $("<form><input tg-remote-noserialize type='file' name='foo'></form>")[0]
+    it 'will not create FormData object if the only input does not have a name', ->
+      form = $("<form><input type='file'></form>")[0]
 
       remote = new TurboGraft.Remote({}, form)
       assert.isFalse (remote.formData instanceof FormData)
 
-    it 'will create FormData object but skip any input with tg-remote-noserialize', ->
-      form = $("<form><input type='file' name='foo'><input tg-remote-noserialize type='file' name='bar'></form>")[0]
+    it 'will create FormData object but skip any input which doesnt have a name', ->
+      form = $("<form><input type='file' name='foo'><input type='file'></form>")[0]
 
       remote = new TurboGraft.Remote({}, form)
       assert (remote.formData instanceof FormData)


### PR DESCRIPTION
fixes https://github.com/Shopify/shopify/issues/37614

In IE11 it appears that serializing file inputs without data causes issues. This PR adds tg-remote-noserialize which can be used to omit such inputs.

review @qq99 @DrewMartin @maartenvg 