### PR TITLE
remove FormData object code path

### DIFF
--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -50,21 +50,9 @@ class TurboGraft.Remote
     @xhr.send(@formData)
 
   createPayload: (form) ->
-    if form
-      cleanForm = form.cloneNode(true)
-      for node in cleanForm.querySelectorAll('input:not([name])')
-        node.parentNode.removeChild(node)
-      if cleanForm.querySelectorAll("[type='file']").length > 0
-        formData = new FormData(cleanForm)
-      else # for much smaller payloads
-        formData = @uriEncodeForm(cleanForm)
-    else
-      formData = ''
-
-    if formData not instanceof FormData
-      @contentType = "application/x-www-form-urlencoded; charset=UTF-8"
-      formData = @formAppend(formData, "_method", @opts.httpRequestType) if formData.indexOf("_method") == -1 && @opts.httpRequestType && @actualRequestType != 'GET'
-
+    formData = @uriEncodeForm(form)
+    @contentType = "application/x-www-form-urlencoded; charset=UTF-8"
+    formData = @formAppend(formData, "_method", @opts.httpRequestType) if formData.indexOf("_method") == -1 && @opts.httpRequestType && @actualRequestType != 'GET'
     formData
 
   formAppend: (uriEncoded, key, value) ->

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -352,24 +352,6 @@ describe 'Remote', ->
 
   describe 'serialization', ->
 
-    it 'will create FormData object if there is a file in the form', ->
-      form = $("<form><input type='file' name='foo'></form>")[0]
-
-      remote = new TurboGraft.Remote({}, form)
-      assert (remote.formData instanceof FormData)
-
-    it 'will not create FormData object if the only input does not have a name', ->
-      form = $("<form><input type='file'></form>")[0]
-
-      remote = new TurboGraft.Remote({}, form)
-      assert.isFalse (remote.formData instanceof FormData)
-
-    it 'will create FormData object but skip any input which doesnt have a name', ->
-      form = $("<form><input type='file' name='foo'><input type='file'></form>")[0]
-
-      remote = new TurboGraft.Remote({}, form)
-      assert (remote.formData instanceof FormData)
-
     it 'will add the _method to the form if supplied in the constructor', ->
       form = $("<form></form>")[0]
 
@@ -382,26 +364,6 @@ describe 'Remote', ->
 
       remote = new TurboGraft.Remote({httpRequestType: 'DELETE'}, form) # DELETE should be ignored here
       assert.equal "_method=PATCH", remote.formData
-
-    it 'will not set _method when using FormData', ->
-      form = $("<form><input type='file' name='foo'></form>")[0]
-
-      oldFormData = window.FormData
-
-      constructed = false
-      window.FormData = class FormData
-        constructor: ->
-          constructed = true
-          @hash = {}
-
-        append: (key, val) ->
-          @hash[key] = val
-
-      remote = new TurboGraft.Remote({httpRequestType: 'DELETE'}, form)
-      assert.equal undefined, remote.formData.hash._method
-      assert.isTrue constructed
-
-      window.FormData = oldFormData
 
     it 'will not add a _method if improperly supplied', ->
       form = $("<form method='POST'></form>")[0]


### PR DESCRIPTION
There appears to be a bug in IE11 where submitting FormData with empty file inputs causes the request to result in 400 Bad request when it otherwise would have been expected to succeed. Given that this functionality seems to be buggy and that we, Shopify, aren't using this in production anyways, this PR proposes the removal of the FormData object code.

@DrewMartin has also been exploring an option https://github.com/Shopify/turbograft/pull/67 where we continue to support FormData, but given that we aren't using the feature and it's problematic to test this might be a better direction.

@qq99 @DrewMartin @Shopify/admin 