### PR TITLE
Optionally prevent PushState on Page.refresh without XHR

### DIFF
--- a/lib/assets/javascripts/turbograft/page.coffee
+++ b/lib/assets/javascripts/turbograft/page.coffee
@@ -19,6 +19,7 @@ Page.refresh = (options = {}, callback) ->
   if options.response
     options.partialReplace = true
     options.onLoadFunction = callback
+
     xhr = options.response
     delete options.response
     Turbolinks.loadPage null, xhr, options

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -111,11 +111,12 @@ class window.Turbolinks
 
   @loadPage: (url, xhr, options = {}) ->
     triggerEvent 'page:receive'
+    options.updatePushState ?= true
 
     if doc = processResponse(xhr, options.partialReplace)
-      reflectNewUrl url
+      reflectNewUrl url if options.updatePushState
       nodes = changePage(extractTitleAndBody(doc)..., options)
-      reflectRedirectedUrl(xhr)
+      reflectRedirectedUrl(xhr) if options.updatePushState
       triggerEvent 'page:load', nodes
       options.onLoadFunction?()
     else

--- a/test/javascripts/page_test.coffee
+++ b/test/javascripts/page_test.coffee
@@ -92,7 +92,26 @@ describe 'Page', ->
         response: mockXHR,
         onlyKeys: ['a']
 
-      @replaceStateStub.calledWith mockXHR.getResponseHeader('X-XHR-Redirected-To')
+      assert @replaceStateStub.calledWith sinon.match.any, '', mockXHR.getResponseHeader('X-XHR-Redirected-To')
+
+    it 'doens\'t update window push state if updatePushState is false', ->
+
+      mockXHR = {
+        getResponseHeader: (header) ->
+          if header == 'Content-Type'
+            return "text/html"
+          else if header == 'X-XHR-Redirected-To'
+            return "http://www.test.com/redirect"
+          ""
+        status: 302
+        responseText: "<div>redirected</div>"
+      }
+      Page.refresh
+        response: mockXHR,
+        onlyKeys: ['a']
+        updatePushState: false
+
+      assert @replaceStateStub.notCalled
 
   describe 'onReplace', ->
 

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -102,6 +102,18 @@ describe 'Turbolinks', ->
         assert @pushStateStub.calledWith({turbolinks: true, url: url_for("/some_request")}, "", url_for("/some_request"))
         assert.equal 0, @replaceStateStub.callCount
 
+      it 'doesn\'t update the window state if updatePushState is false', ->
+        @server.respondWith([200, { "Content-Type": "text/html" }, html_one]);
+
+        Turbolinks.visit "/some_request", {partialReplace: true, onlyKeys: ['turbo-area'], updatePushState: false}
+        @server.respond()
+
+        assert.equal "Hi there!", document.title
+        assert.equal -1, document.body.textContent.indexOf("YOLO")
+        assert document.body.textContent.indexOf("Hi bob") > 0
+        assert @pushStateStub.notCalled
+        assert @replaceStateStub.notCalled
+
       it 'calls a user-supplied callback', ->
         @server.respondWith([200, { "Content-Type": "text/html" }, html_one]);
 


### PR DESCRIPTION
### Introduction

Currently we have 2 ways of doing a Page.refresh (also see #73). One where you have an XHR response you want to use to partially replace things in the page. And another where you give in a URI which you want to visit / (partially) refresh the current page, with or without some queryParams. 

So 

```coffeescript
Page.refresh
  response: xhr
  onlyKeys: [...]
```

vs

```coffeescript
Page.refresh
  url: ... # optional, defaults to current page
  queryParams: {...} # optional
  onlyKeys: [...] # optional, defaults to full page refresh
```

In the first case we don't do a `Turbolinks.pushState` when the refresh is done, which makes sense because you're not leaving the page. In the bottom case we do update the window state, but only if it is a new URL. 9 out of 10 times that's fine, because either you're visiting a completely new URI, or you're refreshing the current page which doesn't trigger the pushState because the URIs are identical.

### Problem

There is a third case when you are trying to refresh the current page, but with new queryParams. This _does_ get recognized as a new URI, and will do a pushState. For example when you are on https://example.com/admin/article/1 and hit a button that does:

```coffeescript
Page.refresh
  queryParams: {'myAwesomeParam': true}
  onlyKeys: ['a_refresh_block']
```
In this case your browser will update the address field to https://example.com/admin/article/1?myAwesomeParam=true.

I'm arguing that there are situations where you want to refresh the page with a query param without actually touching the window state. For example to toggle a hide/show of something that requires new data from the server. In this PR I introduced a new option on `Page.refresh` that propagates down that prevents the page refresh optionally.  But to be honest I don't think it is common that you want to stay on the same URL, but with different query params, and have that reflected in the browser. In that case we could probably get away with just updating [turbolinks#reflectNewUrl](https://github.com/Shopify/turbograft/blob/78829dd7475ff25e15fdcecee81d466fa0fbcec1/lib/assets/javascripts/turbograft/turbolinks.coffee#L251) to ignore query params and only compare the root URIs.

What do you guys think? @qq99 @nsimmons @celsodantas @richardmonette @DrewMartin Which way should we go?

-----

(A work around is doing the call with $.ajax, and using the resulting XHR in 

```coffeescript
Page.refresh
  response: xhr
  onlyKeys: [...]
```
but I feel turbograft should be able to deal with this)