### PR TITLE
Remove nodes with jQuery if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ There is an example app that you can boot to play with TurboGraft.  Open the con
 ./server
 ```
 
+## jQuery and memory leaks
+
+When turbograft replaces or removes a node it uses native DOM API to do so. If any objects use jQuery to listen to events on a node then these objects will leak when the node is replaced because jQuery will still have references to it. To clean these up you'll need to tell jQuery that they're removed. This can be done with something like:
+
+```coffeescript
+document.addEventListener 'page:after-node-removed', (event) ->
+  $(event.data).remove()
+```
+
 ## Contributing
 
 1. Fork it ( http://github.com/Shopify/turbograft/fork )

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -48,6 +48,14 @@ if browserSupportsCustomEvents
   installDocumentReadyPageEventTriggers()
   installJqueryAjaxSuccessPageUpdateTrigger()
 
+replaceNode = (newNode, oldNode) ->
+  replacedNode = oldNode.parentNode.replaceChild(newNode, oldNode)
+  triggerEvent('page:after-node-removed', replacedNode)
+
+removeNode = (node) ->
+  removedNode = node.parentNode.removeChild(node)
+  triggerEvent('page:after-node-removed', removedNode)
+
 # TODO: triggerEvent should be accessible to all these guys
 # on some kind of eventbus
 # TODO: clean up everything above me ^
@@ -129,7 +137,7 @@ class window.Turbolinks
         deleteRefreshNeverNodes(body)
 
       triggerEvent 'page:before-replace'
-      document.documentElement.replaceChild body, document.body
+      replaceNode(body, document.body)
       CSRFToken.update csrfToken if csrfToken?
       setAutofocusElement()
       executeScriptTags() if runScripts
@@ -168,7 +176,7 @@ class window.Turbolinks
 
   deleteRefreshNeverNodes = (body) ->
     for node in body.querySelectorAll('[refresh-never]')
-      node.parentNode.removeChild(node)
+      removeNode(node)
 
     return
 
@@ -189,7 +197,7 @@ class window.Turbolinks
 
       if newNode = body.querySelector("##{ nodeId }")
         newNode = newNode.cloneNode(true)
-        existingNode.parentNode.replaceChild(newNode, existingNode)
+        replaceNode(newNode, existingNode)
 
         if newNode.nodeName == 'SCRIPT' && newNode.getAttribute("data-turbolinks-eval") != "false"
           executeScriptTag(newNode)
@@ -197,7 +205,7 @@ class window.Turbolinks
           refreshedNodes.push(newNode)
 
       else if existingNode.getAttribute("refresh-always") == null
-        existingNode.parentNode.removeChild(existingNode)
+        removeNode(existingNode)
 
     refreshedNodes
 
@@ -207,7 +215,7 @@ class window.Turbolinks
         throw new Error("TurboGraft refresh: Kept nodes must have an id.")
 
       if remoteNode = body.querySelector("##{ nodeId }")
-        remoteNode.parentNode.replaceChild(existingNode, remoteNode)
+        replaceNode(existingNode, remoteNode)
 
   persistStaticElements = (body) ->
     allNodesToKeep = []


### PR DESCRIPTION
Because of how we replace nodes anything that has jQuery event handlers attached (explicitly attached, not through Twine) will cause the listening object to leak. For example our Form object does several $.on calls in the constructor and because of this it will never be cleaned up. jQuery event handlers are are only cleaned up when you use jQuery methods to remove the nodes.

When calling [remove](http://api.jquery.com/remove/) and [replaceWith](http://api.jquery.com/replaceWith/) "all bound events and jQuery data associated with the elements are removed"

Review
@Thibaut @qq99 @kristianpd @arthurnn 
We should probably push this upstream to turbolinks. Glancing at their code I believe it will have the same problem
Also I'm not sure how to write tests for memory leaks