### PR TITLE
port over Page.onReplace for reliably running a callback after the node in question has been removed from the DOM

### DIFF
--- a/lib/assets/javascripts/turbograft/page.coffee
+++ b/lib/assets/javascripts/turbograft/page.coffee
@@ -25,3 +25,47 @@ Page.refresh = (options = {}, callback) ->
 
 Page.open = ->
   window.open(arguments...)
+
+# Providing hooks for objects to set up destructors:
+onReplaceCallbacks = []
+
+# e.g., Page.onReplace(node, unbindListenersFnc)
+# unbindListenersFnc will be called if the node in question is partially replaced
+# or if a full replace occurs.  It will be called only once
+Page.onReplace = (node, callback) ->
+  throw new Error("Page.onReplace: Node and callback must both be specified") if !node || !callback
+  throw new Error("Page.onReplace: Callback must be a function") if !isFunction(callback)
+  onReplaceCallbacks.push({node, callback})
+
+# option C from http://jsperf.com/alternative-isfunction-implementations
+isFunction = (object) ->
+  !!(object && object.constructor && object.call && object.apply)
+
+# roughly based on http://davidwalsh.name/check-parent-node (note, OP is incorrect)
+contains = (parentNode, childNode) ->
+  if parentNode.contains
+    parentNode.contains(childNode)
+  else # old browser compatability
+    !!((parentNode == childNode) || (parentNode.compareDocumentPosition(childNode) & Node.DOCUMENT_POSITION_CONTAINED_BY))
+
+document.addEventListener 'page:before-partial-replace', (event) ->
+  replacedNodes = event.data
+
+  unprocessedOnReplaceCallbacks = []
+  for entry in onReplaceCallbacks
+    fired = false
+    for replacedNode in replacedNodes
+      if contains(replacedNode, entry.node)
+        entry.callback()
+        fired = true
+        break
+
+    unless fired
+      unprocessedOnReplaceCallbacks.push(entry)
+
+  onReplaceCallbacks = unprocessedOnReplaceCallbacks
+
+document.addEventListener 'page:before-replace', (event) ->
+  for entry in onReplaceCallbacks
+    entry.callback()
+  onReplaceCallbacks = []


### PR DESCRIPTION
This allows the user of TurboGraft to register a function to be called *exactly once* when a specific node has been refreshed (be it a full page refresh, or a partial page refresh).

This is mostly a port of what we have in `modules.coffee` in Shopify.  I have not ported `Page.onRefresh` since that definition is more tied to Twine-y things

## Example Usage

```coffee
class MyFoo
  constructor: (@node) ->
    @bindSomeEventsOn(@node)
    Page.onReplace(@node, @unbindSomeEvents.bind(this)) # we want to clean up all the events we bound to prevent leaking

  unbindSomeEvents = ->
    ... # undo whatever we did in the `bindSomeEvents` function
```

cc @DrewMartin for primary review
cc also @patrickdonovan @tylermercier @nsimmons @celsodantas 

