### PR TITLE
add tg-remote-noserialize attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ Examples of where this may be useful include:
 
 For the lazy developer in all of us, we can use the attribute `refresh-always` when we want to be sure we've absolutely replaced a certain element, if it exists.  An example of such a node you may want to apply this might be an unread notification count -- always being sure to update it if it exists in the response.
 
+### tg-remote-noserialize
+
+When serializing forms for tg-remote calls, turbograft will check to ensure inputs meet the following criteria:
+
+- the input has a `name` attribute
+- the input does not have the `disabled` attribute
+
+and
+
+- the input does not have the `tg-remote-noserialize`
+
+The `tg-remote-noserialize` is useful in scenarios where the input should be editable, i.e. not `disabled`, but should also not be submitted to the server.
+
 ## Example App
 
 There is an example app that you can boot to play with TurboGraft.  Open the console and network inspector and see it in action!  This same app is also used in the TurboGraft browser testing suite.

--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -92,7 +92,7 @@ class TurboGraft.Remote
   _iterateOverFormInputs: (form, callback) ->
     inputs = form.querySelectorAll("input:not([type='reset']):not([type='button']):not([type='submit']):not([type='image']), select, textarea")
     for input in inputs
-      inputEnabled = !input.disabled
+      inputEnabled = !input.disabled && !input.hasAttribute('tg-remote-noserialize')
       radioOrCheck = (input.type == 'checkbox' || input.type == 'radio')
 
       if inputEnabled && input.name

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -462,6 +462,18 @@ describe 'Remote', ->
       remote = new TurboGraft.Remote({}, form)
       assert.equal "foo=bar", remote.formData
 
+    it 'will not URL encode fields which have tg-no-serialize', ->
+      formDesc = """
+      <form>
+        <input type="text" name="foo" value="bar">
+        <input type="text" name="faa" value="bat" tg-remote-noserialize>
+      </form>
+      """
+      form = $(formDesc)[0]
+
+      remote = new TurboGraft.Remote({}, form)
+      assert.equal "foo=bar", remote.formData
+
     it 'properly URL encodes multiple fields in the form', ->
       formDesc = """
       <form>


### PR DESCRIPTION
Currently, to avoid serialization, an input can either a) not have a name attribute or b) have the disabled attribute. This is problematic in situations where an input should have a name and be enabled, such that it can be edited, but may not need to serialized. 

This PR introduces `tg-remote-noserialize` which, when it appears on an input, will cause it to be omitted from serialization.

@qq99 @pushrax @nsimmons @DrewMartin @maartenvg