### PR TITLE
Add attribute that prevents serialization of a subtree

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ Examples of where this may be useful include:
 
 For the lazy developer in all of us, we can use the attribute `refresh-always` when we want to be sure we've absolutely replaced a certain element, if it exists.  An example of such a node you may want to apply this might be an unread notification count -- always being sure to update it if it exists in the response.
 
+### tg-remote-noserialize
+
+When serializing forms for tg-remote calls, turbograft will check to ensure inputs meet the following criteria:
+
+- the input has a `name` attribute
+- the input does not have the `disabled` attribute
+
+and
+
+- the input does not have the `tg-remote-noserialize` attribute
+- no ancestor of the input has the `tg-remote-noserialize` attribute
+
+The `tg-remote-noserialize` is useful in scenarios where a whole section of the page should be editable, i.e. not `disabled`, but should only conditionally be submitted to the server.
+
 ## Example App
 
 There is an example app that you can boot to play with TurboGraft.  Open the console and network inspector and see it in action!  This same app is also used in the TurboGraft browser testing suite.

--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -90,7 +90,7 @@ class TurboGraft.Remote
     formData
 
   _iterateOverFormInputs: (form, callback) ->
-    inputs = form.querySelectorAll("input:not([type='reset']):not([type='button']):not([type='submit']):not([type='image']), select, textarea")
+    inputs = @_enabledInputs(form)
     for input in inputs
       inputEnabled = !input.disabled
       radioOrCheck = (input.type == 'checkbox' || input.type == 'radio')
@@ -98,6 +98,22 @@ class TurboGraft.Remote
       if inputEnabled && input.name
         if (radioOrCheck && input.checked) || !radioOrCheck
           callback(input)
+
+  _enabledInputs: (form) ->
+    selector = "input:not([type='reset']):not([type='button']):not([type='submit']):not([type='image']), select, textarea"
+    inputs = Array::slice.call(form.querySelectorAll(selector))
+    disabledNodes = Array::slice.call(form.querySelectorAll("[tg-remote-noserialize]"))
+
+    return inputs unless disabledNodes.length
+
+    disabledInputs = disabledNodes
+    for node in disabledNodes
+      disabledInputs = disabledInputs.concat(Array::slice.call(node.querySelectorAll(selector)))
+
+    enabledInputs = []
+    for input in inputs when disabledInputs.indexOf(input) < 0
+      enabledInputs.push(input)
+    enabledInputs
 
   onSuccess: (ev) ->
     @opts.success?()

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -494,3 +494,43 @@ describe 'Remote', ->
 
       remote = new TurboGraft.Remote({}, form)
       assert.equal "application/x-www-form-urlencoded; charset=UTF-8", remote.xhr.requestHeaders["Content-Type"]
+
+    it 'will ignore inputs with the tg-remote-noserialize attribute on them or on an ancestor', ->
+      formDesc = """
+      <form>
+        <input type="text" name="foo" value="bar" tg-remote-noserialize>
+        <input type="text" name="faa" value="bat">
+        <input type="text" name="fii" value="bam+">
+        <textarea name="textarea">this is a test</textarea>
+        <input type="text" name="disabled" disabled value="disabled">
+        <input type="radio" name="radio1" value="A">
+        <input type="radio" name="radio1" value="B" checked>
+        <input type="checkbox" name="checkbox" value="C">
+        <input type="checkbox" name="checkbox" value="D" checked>
+        <input type="checkbox" name="disabled2" value="checked" checked disabled>
+        <select name="select1">
+          <option value="a">foo</option>
+          <option value="b">foo</option>
+          <option value="c" selected>foo</option>
+        </select>
+        <input type="text" name="foobar" value="foobat">
+        <div tg-remote-noserialize>
+          <span>
+            <input type="text" name="nope" value="nope">
+            <textarea name="textarea2" tg-remote-noserialize>this is also a test</textarea>
+            <input type="radio" name="radio2" value="Y">
+            <input type="radio" name="radio2" value="X" checked>
+            <select name="select2">
+              <option value="x">foo</option>
+              <option value="y">foo</option>
+              <option value="z" selected>foo</option>
+            </select>
+          </span>
+        </div>
+      </form>
+      """
+
+      form = $(formDesc)[0]
+
+      remote = new TurboGraft.Remote({}, form)
+      assert.equal "faa=bat&fii=bam%2B&textarea=this%20is%20a%20test&radio1=B&checkbox=D&select1=c&foobar=foobat", remote.formData


### PR DESCRIPTION
Modified version of #80

This adds a `tg-remote-noserialize` attribute, but unlike the last one it prevents serialization of a node and its subtree. Consider a field that has many inputs inside of it which you want to serialize together, conditionally. Either they're all sent or none of them are. Rather than putting disabled on them individually we can just put `tg-remote-noserialize` on some ancestor of them.

My biggest concern for this was performance. I tried a few different methods and benchmarked them [here](http://jsperf.com/finding-enabled-inputs-by-attribute/3). Tl;dr this method's the fastest in general. In practical terms I tried making a product with 100 variants and 100+ tags, for about 1300 inputs within the main product#show form. I put `tg-remote-noserialize` on each variant row individually, so 100 instances of it on the page. Getting the enabled inputs took between 8-15 ms per run. With only two rows with the attribute it was 2-4 ms.

Performance could be improved further if we were to use Set or WeakSet (since any object can be a key and uniquely identified) but it's still experimental and doesn't have widespread support. Assuming `n` is the number of inputs and `m` is the number of nodes with disabled attributes, it could take the run time from `O(m*n)` to `O(m+n)`. With the speeds we're seeing it would probably be unnecessary though.

TODO:
* [ ] Docs

Review: @qq99 @richardmonette 
@Shopify/admin 