### PR TITLE
add option to specify using native encoding

### DIFF
--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -4,6 +4,7 @@ class TurboGraft.Remote
     @initiator = form || target
 
     @actualRequestType = if @opts.httpRequestType?.toLowerCase() == 'get' then 'GET' else 'POST'
+    @useNativeEncoding = @opts.useNativeEncoding
 
     @formData = @createPayload(form)
 
@@ -52,7 +53,7 @@ class TurboGraft.Remote
 
   createPayload: (form) ->
     if form
-      if form.querySelectorAll("[type='file'][name]").length > 0
+      if @useNativeEncoding || form.querySelectorAll("[type='file'][name]").length > 0
         formData = @nativeEncodeForm(form)
       else # for much smaller payloads
         formData = @uriEncodeForm(form)

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -457,6 +457,12 @@ describe 'Remote', ->
       remote = new TurboGraft.Remote({httpRequestType: undefined}, form)
       assert.equal "", remote.formData
 
+    it 'will create FormData object even if there is no file when useNativeEncoding specified', ->
+      form = $("<form><input type='text' name='foo' value='bar'></form>")[0]
+
+      remote = new TurboGraft.Remote({useNativeEncoding: true}, form)
+      assert (remote.formData instanceof FormData)
+
     it 'will not create FormData object if there is no file in the form', ->
       form = $("<form><input type='text' name='foo' value='bar'></form>")[0]
 


### PR DESCRIPTION
There are certain situations where it is necessary to use native FormData encoding where `Turbograft.Remote` would not have automatically selected that type of form encoding (https://github.com/Shopify/shopify/pull/43275). 

Therefore, this PR adds an option to `Turbograft.Remote` which allows for specifying that native encoding being used. When not specified, the behaviour is the same as before, i.e. attempt to use URL encoding except when input fields are present.

review @qq99 @DrewMartin @maartenvg 
cc @Shopify/tnt 