### PR TITLE
Allow passing request headers using Turbolinks.visit API.

### DIFF
--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -95,6 +95,9 @@ class window.Turbolinks
     xhr.setRequestHeader 'Accept', 'text/html, application/xhtml+xml, application/xml'
     xhr.setRequestHeader 'X-XHR-Referer', referer
 
+    options.headers ?= []
+    xhr.setRequestHeader options.headers[header].key, options.headers[header].value for header of options.headers
+
     xhr.onload = ->
       if xhr.status >= 500
         document.location.href = url.absolute

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -95,8 +95,10 @@ class window.Turbolinks
     xhr.setRequestHeader 'Accept', 'text/html, application/xhtml+xml, application/xml'
     xhr.setRequestHeader 'X-XHR-Referer', referer
 
-    options.headers ?= []
-    xhr.setRequestHeader options.headers[header].key, options.headers[header].value for header of options.headers
+    options.headers ?= {}
+
+    for k,v of options.headers
+      xhr.setRequestHeader k, v
 
     xhr.onload = ->
       if xhr.status >= 500

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -88,6 +88,16 @@ describe 'Turbolinks', ->
 
       window.removeEventListener('page:before-change', listener)
 
+    it 'supports passing request headers', ->
+      @server.respondWith([200, { "Content-Type": "text/html" }, "<html>Hello World</html>"]);
+
+      Turbolinks.visit "/some_request", {headers: {'foo': 'bar', 'fizz': 'buzz'}}
+      @server.respond()
+
+      assert.equal 1, @server.requests.length
+      assert.equal 'bar', @server.requests[0].requestHeaders['foo']
+      assert.equal 'buzz', @server.requests[0].requestHeaders['fizz']
+
     describe 'with partial page replacement', ->
       it 'uses just the part of the response body we supply', ->
         @server.respondWith([200, { "Content-Type": "text/html" }, html_one]);


### PR DESCRIPTION
We'd like to programmatically call `Turbolinks.visit` with specific request headers - this PR allows passing headers into the options argument.

Example:
```javascript
Turbolinks.visit('my/resource', {headers: {'foo': 'bar'}});
```