### PR TITLE
Fix historyState bug with tg-remote

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ env:
   - DISPLAY=':99.0'  RAILS_VERSION='4.1.0'
   - DISPLAY=':99.0'  RAILS_VERSION='4.2.0'
 script: bundle exec rake ci
+sudo: false

--- a/lib/assets/javascripts/turbograft/initializers.coffee
+++ b/lib/assets/javascripts/turbograft/initializers.coffee
@@ -17,6 +17,7 @@ setupRemoteFromTarget = (target, httpRequestType, form = null) ->
     httpRequestType: httpRequestType
     httpUrl: httpUrl
     fullRefresh: TurboGraft.getTGAttribute(target, 'full-refresh')?
+    updatePushState: TurboGraft.hasTGAttribute(target, 'tg-update-historystate')
     refreshOnSuccess: TurboGraft.getTGAttribute(target, 'refresh-on-success')
     refreshOnSuccessExcept: TurboGraft.getTGAttribute(target, 'full-refresh-on-success-except')
     refreshOnError: TurboGraft.getTGAttribute(target, 'refresh-on-error')

--- a/lib/assets/javascripts/turbograft/page.coffee
+++ b/lib/assets/javascripts/turbograft/page.coffee
@@ -20,9 +20,11 @@ Page.refresh = (options = {}, callback) ->
     options.partialReplace = true
     options.onLoadFunction = callback
 
+    url = options.url
     xhr = options.response
     delete options.response
-    Turbolinks.loadPage null, xhr, options
+    delete options.url
+    Turbolinks.loadPage url, xhr, options
   else
     options.partialReplace = true
     options.callback = callback if callback

--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -130,19 +130,25 @@ class TurboGraft.Remote
 
     unless TurboGraft.hasTGAttribute(@initiator, 'tg-remote-norefresh')
       if @opts.fullRefresh && @refreshOnSuccess
-        Page.refresh(onlyKeys: @refreshOnSuccess)
+        Page.refresh
+          url: @opts.httpUrl
+          onlyKeys: @refreshOnSuccess
       else if @opts.fullRefresh
-        Page.refresh()
+        Page.refresh
+          url: @opts.httpUrl
       else if @refreshOnSuccess
         Page.refresh
+          url: @opts.httpUrl
           response: xhr
           onlyKeys: @refreshOnSuccess
       else if @refreshOnSuccessExcept
         Page.refresh
+          url: @opts.httpUrl
           response: xhr
           exceptKeys: @refreshOnSuccessExcept
       else
         Page.refresh
+          url: @opts.httpUrl
           response: xhr
 
   onError: (ev) ->
@@ -155,10 +161,12 @@ class TurboGraft.Remote
 
     if @refreshOnError
       Page.refresh
+        url: @opts.httpUrl
         response: xhr
         onlyKeys: @refreshOnError
     else if @refreshOnErrorExcept
       Page.refresh
+        url: @opts.httpUrl
         response: xhr
         exceptKeys: @refreshOnErrorExcept
     else

--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -5,6 +5,7 @@ class TurboGraft.Remote
 
     @actualRequestType = if @opts.httpRequestType?.toLowerCase() == 'get' then 'GET' else 'POST'
     @useNativeEncoding = @opts.useNativeEncoding
+    @updatePushState = !!@opts.updatePushState
 
     @formData = @createPayload(form)
 
@@ -133,23 +134,28 @@ class TurboGraft.Remote
         Page.refresh
           url: @opts.httpUrl
           onlyKeys: @refreshOnSuccess
+          updatePushState: @updatePushState
       else if @opts.fullRefresh
         Page.refresh
           url: @opts.httpUrl
+          updatePushState: @updatePushState
       else if @refreshOnSuccess
         Page.refresh
           url: @opts.httpUrl
           response: xhr
           onlyKeys: @refreshOnSuccess
+          updatePushState: @updatePushState
       else if @refreshOnSuccessExcept
         Page.refresh
           url: @opts.httpUrl
           response: xhr
           exceptKeys: @refreshOnSuccessExcept
+          updatePushState: @updatePushState
       else
         Page.refresh
           url: @opts.httpUrl
           response: xhr
+          updatePushState: @updatePushState
 
   onError: (ev) ->
     @opts.fail?()

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -115,6 +115,8 @@ class window.Turbolinks
     return
 
   @loadPage: (url, xhr, options = {}) ->
+    rememberReferer()
+
     triggerEvent 'page:receive'
     options.updatePushState ?= true
 

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -272,10 +272,7 @@ class window.Turbolinks
     return
 
   reflectRedirectedUrl = (xhr) ->
-    if location = xhr.getResponseHeader 'X-XHR-Redirected-To'
-      location = new ComponentUrl location
-      preservedHash = if location.hasNoHash() then document.location.hash else ''
-      Turbolinks.replaceState currentState, '', location.href + preservedHash
+    reflectNewUrl(location) if location = xhr.getResponseHeader 'X-XHR-Redirected-To'
     return
 
   rememberReferer = ->

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -74,6 +74,7 @@ class window.Turbolinks
 
     options.partialReplace ?= false
     options.onlyKeys ?= []
+    options.updatePushState ?= true
     options.onLoadFunction = ->
       resetScrollPosition() unless options.onlyKeys.length
       options.callback?()
@@ -115,10 +116,7 @@ class window.Turbolinks
     return
 
   @loadPage: (url, xhr, options = {}) ->
-    rememberReferer()
-
     triggerEvent 'page:receive'
-    options.updatePushState ?= true
 
     if doc = processResponse(xhr, options.partialReplace)
       reflectNewUrl url if options.updatePushState

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -121,7 +121,7 @@ class window.Turbolinks
     if doc = processResponse(xhr, options.partialReplace)
       reflectNewUrl url if options.updatePushState
       nodes = changePage(extractTitleAndBody(doc)..., options)
-      reflectRedirectedUrl(xhr) if options.updatePushState
+      reflectRedirectedUrl(xhr)
       triggerEvent 'page:load', nodes
       options.onLoadFunction?()
     else

--- a/test/browser/partial_page_refresh_test.rb
+++ b/test/browser/partial_page_refresh_test.rb
@@ -21,29 +21,21 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     assert_equal random_b, find('#random-number-b').text
   end
 
-  test "can refresh just one section at a time" do
-    random_a = find('#random-number-a').text
-    random_b = find('#random-number-b').text
-
-    assert random_a
-    assert random_b
-
-    click_button "Refresh Section A"
+  test "can refresh just section A, section B, or section A&B at the same time" do
+    expect_section_a_differs do
+      click_button "Refresh Section A"
+    end
     assert page.has_content?("page 1")
-    assert_not_equal random_a, find('#random-number-a').text
-    assert_equal random_b, find('#random-number-b').text
 
-    random_a = find('#random-number-a').text
-    click_button "Refresh Section B"
+    expect_section_b_differs do
+      click_button "Refresh Section B"
+    end
     assert page.has_content?("page 1")
-    assert_equal random_a, find('#random-number-a').text
-    assert_not_equal random_b, find('#random-number-b').text
 
-    random_b = find('#random-number-b').text
-    click_button "Refresh Section A and B"
+    expect_sections_a_and_b_differ do
+      click_button "Refresh Section A and B"
+    end
     assert page.has_content?("page 1")
-    assert_not_equal random_a, find('#random-number-a').text
-    assert_not_equal random_b, find('#random-number-b').text
   end
 
   test "when I use an XHR and POST to an endpoint that returns me a 302, I should see the URL reflecting that redirect too" do
@@ -144,13 +136,12 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     assert page.has_content?("Your foo has been destroyed.")
   end
 
-  test "tg-remote refreshing the same URL will not push onto history stack" do
+  test "tg-remote refreshing the same URL multiple times will not push copies onto the history stack" do
     visit "/pages/2"
 
     expect_sections_a_and_b_differ do
       click_link "Perform a partial page refresh of the current page"
     end
-
     expect_sections_a_and_b_differ do
       click_link "Perform a partial page refresh of the current page"
     end
@@ -158,7 +149,6 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     page.evaluate_script('window.history.back()')
 
     assert page.has_content?("page 1")
-
   end
 
   def expect_sections_a_and_b_differ(&block)
@@ -168,6 +158,26 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     yield
 
     assert_not_equal random_a, find('#random-number-a').text
+    assert_not_equal random_b, find('#random-number-b').text
+  end
+
+  def expect_section_a_differs(&block)
+    assert random_a = find('#random-number-a').text
+    assert random_b = find('#random-number-b').text
+
+    yield
+
+    assert_not_equal random_a, find('#random-number-a').text
+    assert_equal random_b, find('#random-number-b').text
+  end
+
+  def expect_section_b_differs(&block)
+    assert random_a = find('#random-number-a').text
+    assert random_b = find('#random-number-b').text
+
+    yield
+
+    assert_equal random_a, find('#random-number-a').text
     assert_not_equal random_b, find('#random-number-b').text
   end
 end

--- a/test/browser/partial_page_refresh_test.rb
+++ b/test/browser/partial_page_refresh_test.rb
@@ -143,4 +143,31 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     refute page.has_content?("Please confirm that you want to delete this foo.")
     assert page.has_content?("Your foo has been destroyed.")
   end
+
+  test "tg-remote refreshing the same URL will not push onto history stack" do
+    visit "/pages/2"
+
+    expect_sections_a_and_b_differ do
+      click_link "Perform a partial page refresh of the current page"
+    end
+
+    expect_sections_a_and_b_differ do
+      click_link "Perform a partial page refresh of the current page"
+    end
+
+    page.evaluate_script('window.history.back()')
+
+    assert page.has_content?("page 1")
+
+  end
+
+  def expect_sections_a_and_b_differ(&block)
+    assert random_a = find('#random-number-a').text
+    assert random_b = find('#random-number-b').text
+
+    yield
+
+    assert_not_equal random_a, find('#random-number-a').text
+    assert_not_equal random_b, find('#random-number-b').text
+  end
 end

--- a/test/example/app/views/pages/show.html.erb
+++ b/test/example/app/views/pages/show.html.erb
@@ -179,10 +179,13 @@
 
 
 <div class="prepend-pre">
-<a href="<%= page_path(rand(100)) %>" data-tg-remote="GET" data-tg-refresh-on-success="page section-a section-b">
+<a id='random-page-link' refresh='page' href="<%= page_path(rand(100)) %>" data-tg-remote="GET" data-tg-refresh-on-success="page section-a section-b">
   <i>data-tg-remote GET to response of 200</i>
 </a>
 </div>
+<p>
+  The above is useful to navigate elsewhere while refreshing part of the page.
+</p>
 
 <div class="prepend-pre">
 <a href="<%= page_path(rand(100)) %>" data-tg-remote="GET" data-tg-full-refresh-on-success-except="section-a">

--- a/test/example/app/views/pages/show.html.erb
+++ b/test/example/app/views/pages/show.html.erb
@@ -198,7 +198,14 @@
 <a href="<%= error_422_with_show_pages_path %>" data-tg-remote="GET" data-tg-full-refresh-on-error-except="section-a">data-tg-remote GET to response of 422 replaces everything except side-bar-a</a>
 </div>
 
-<h3>data-tg-remote links of various method types, with data-tg-remote-norefresh</h3>
+<div class="prepend-pre">
+<%= link_to "Perform a partial page refresh of the current page", page_path(@id), "data-tg-remote" => "GET", "data-tg-refresh-on-success" => "page section-a section-b" %>
+</div>
+<p>
+  The above is useful to re-update just parts of the page (should they have changed since the user last visited it).
+</p>
+
+<h3>tg-remote links of various method types, with tg-remote-norefresh</h3>
 <p>No visible side effects here, so open your Network inspector to see them in action.</p>
 <div class="prepend-pre">
 <a href="/pages/method_agnostic" data-tg-remote="GET" data-tg-remote-norefresh>data-tg-remote GET</a><br>


### PR DESCRIPTION
Fixes https://github.com/Shopify/turbograft/issues/96

If you were to call `Turbolinks.loadPage` directly (bypassing `Turbolinks.visit`), `rememberReferer` would not be called.  `tg-remote` does exactly this via `Page.refresh` and supplying an `xhr` in `page.coffee`.

This PR duplicates a call to `rememberReferer`, but should have no effect in the `Turbolinks.visit` case since it's just performing the same thing twice.  It's feels a little unfortunate that it had to be duplicated

I think that this is a proper fix because:

- if you navigate from page A > B > C without this patch, a `tg-remote` that didn't result in a redirect would have `B` as the referer, and re-push `C` onto the stack to result in A > B > C > C
- a partial replace should probably care about its referer much in the same way that a regular navigation cares about its referer

I've tested it out on my own project with the back & forward buttons in these scenarios:

- regular navigations
- tg-remote with only an action (aka `xhr` but no `onlyKeys`)
- tg-remote with an action and `refresh-on-success` (`xhr` + `onlyKeys`)

Also good for testing is the example app (added a new button + test for this kind of behaviour)

*Don't merge*: still need to fix:

- tg-remote GET where you want to replace parts of the page and update the URL in history
- tg-remote GET where you want to replace parts of the page and keep URL as it was (no history altering)

cc @Shopify/tnt 