### PR TITLE
Use prepend instead of alias_method_chain

### DIFF
--- a/lib/turbograft.rb
+++ b/lib/turbograft.rb
@@ -36,9 +36,9 @@ module TurboGraft
 
       ActiveSupport.on_load(:action_view) do
         (ActionView::RoutingUrlFor rescue ActionView::Helpers::UrlHelper).module_eval do
-          include XHRUrlFor
+          prepend XHRUrlFor
         end
-      end unless RUBY_VERSION =~ /^1\.8/
+      end unless RUBY_VERSION =~ /^1\./
     end
   end
 end

--- a/lib/turbograft/xhr_url_for.rb
+++ b/lib/turbograft/xhr_url_for.rb
@@ -3,13 +3,9 @@ module TurboGraft
   # option by using the X-XHR-Referer request header instead of the standard Referer
   # request header.
   module XHRUrlFor
-    def self.included(base)
-      base.alias_method_chain :url_for, :xhr_referer
-    end
-
-    def url_for_with_xhr_referer(options = {})
+    def url_for(options = {})
       options = (controller.request.headers["X-XHR-Referer"] || options) if options == :back
-      url_for_without_xhr_referer options
+      super options
     end
   end
 end


### PR DESCRIPTION
Using Turbograft with Turbolinks 3 results in a StackTooDeep error since it started using [`prepend` instead of `alias_method_chain`](https://github.com/rails/turbolinks/commit/a6175e9ca426c3c6d7f74c6b2346488513897825). 


The reason is because the view ancestors are as such:

```
[
 ...
 Turbolinks::XHRUrlFor,
 ...
 TurboGraft::XHRUrlFor,
]
```

Because the `url_for` method for that class is defined before TurboGraft in the inheritance class, using `alias_method_chain` means that the `url_for_without_` effectively calls Turoblinks's implementation.

@Thibaut @pushrax 