### PR TITLE
Don’t set request_method cookie for GET requests

### DIFF
--- a/lib/turbograft/cookies.rb
+++ b/lib/turbograft/cookies.rb
@@ -1,10 +1,14 @@
 module TurboGraft
   # Sets a request_method cookie containing the request method of the current request.
-  # The Turbolinks script will not initialize if this cookie is set to anything other than GET.
+  # The Turbolinks script will not initialize if this cookie is not set, or set to anything other than GET.
   module Cookies
     private
       def set_request_method_cookie
-        cookies[:request_method] = request.request_method
+        if request.get?
+          cookies.delete(:request_method)
+        else
+          cookies[:request_method] = request.request_method
+        end
       end
   end
 end

--- a/test/controller/pages_controller_test.rb
+++ b/test/controller/pages_controller_test.rb
@@ -1,9 +1,14 @@
 require 'test_helper'
 
 class PagesControllerTest < ActionController::TestCase
-  test "set_request_method_cookie sets request method" do
+  test "set_request_method_cookie does not set cookie for GET requests" do
     get :show
-    assert_equal 'GET', cookies[:request_method]
+    refute response.headers.key?('Set-Cookie')
+  end
+
+  test "set_request_method_cookie sets request method for non GET requests" do
+    post :show
+    assert_equal 'POST', cookies[:request_method]
   end
 
   test "redirect_via_turbolinks_to sets response body and status" do


### PR DESCRIPTION
The presence of a `Set-Cookie` header prevents CDNs from caching a page, so we want to prevent cookies from being set unnecessarily. Turbolinks/Turbograft will assume a request is a GET request if the cookie is not set, so doesn’t doesn’t change Turbograft’s behaviour. 

This mirrors https://github.com/rails/turbolinks/commit/62cc3db457ad9745ccda047dd43ab84fb3d89707

Review: @pushrax @patrickdonovan, cc @mtaher @Shopify/cloud 