### PR TITLE
Make redirect_via_turbolinks_to protected

### DIFF
--- a/lib/turbograft/redirection.rb
+++ b/lib/turbograft/redirection.rb
@@ -4,6 +4,7 @@ module TurboGraft
   module Redirection
     extend ActiveSupport::Concern
 
+    private
     def redirect_via_turbolinks_to(url = {}, response_status = {})
       redirect_to(url, response_status)
 


### PR DESCRIPTION
I am trying to ensure all public methods are routable, and this one is public but not routable in Shopify.

@pushrax @DrewMartin 