### PR TITLE
Fix TG from removing nodes using data prefix on refresh-always

### DIFF
--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -215,7 +215,8 @@ class window.Turbolinks
         else
           refreshedNodes.push(newNode)
 
-      else if TurboGraft.getTGAttribute(existingNode, "refresh-always") == null
+      else if (TurboGraft.getTGAttribute(existingNode, "refresh-always") == null &&
+               TurboGraft.getTGAttribute(existingNode, "data-tg-refresh-always") == null)
         removeNode(existingNode)
 
     refreshedNodes


### PR DESCRIPTION
Proposed fix to: https://github.com/Shopify/shopify/issues/67947

Reasoning for Multiline conditional:
 * Nowhere to store the `getTGAttribute` calls ahead of time since this is in an `if... else if...` block. If I evaluate them before the `if... else if...` block then they could be evaluated but not used if the `if` case was entered.
 * Long lines are bad.
 * It's got some documentation around it: https://github.com/jashkenas/coffeescript/issues/966

@qq99 @nwtn 