### PR TITLE
fix obscure refresh-always bug that presents when using data-tg-refresh-always vs refresh-always

### DIFF
--- a/lib/assets/javascripts/turbograft.coffee
+++ b/lib/assets/javascripts/turbograft.coffee
@@ -20,7 +20,7 @@ TurboGraft.removeTGAttribute = (node, attr) ->
 
 TurboGraft.hasTGAttribute = (node, attr) ->
   tgAttr = TurboGraft.tgAttribute(attr)
-  node.getAttribute(tgAttr)? || node.getAttribute(attr)?
+  node.hasAttribute(tgAttr) || node.hasAttribute(attr)
 
 TurboGraft.querySelectorAllTGAttribute = (node, attr, value = null) ->
   tgAttr = TurboGraft.tgAttribute(attr)

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -215,7 +215,7 @@ class window.Turbolinks
         else
           refreshedNodes.push(newNode)
 
-      else if TurboGraft.getTGAttribute(existingNode, "refresh-always") == null
+      else if !TurboGraft.hasTGAttribute(existingNode, "refresh-always")
         removeNode(existingNode)
 
     refreshedNodes


### PR DESCRIPTION
See #114 for discussion

~~Testing this now~~ Works for me!

Only tg-remote seems to use `hasTGAttribute`, and from what I can see, these still work too

cc @dfmcphee @justinthec @Shopify/tnt 