### PR TITLE
[Fixes Master CI] Allow full refresh to respond to 422

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
-  - '2.0.0'
-  - '2.1.2'
-  - '2.2.0'
+  - '2.2.2'
 before_script:
   - sh -e /etc/init.d/xvfb start
   - bundle install

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ It requires your `<form>`, `<a>`, or `<button>` to be marked up with:
 * `data-tg-refresh-on-error`: (optional) The refresh keys to be refreshed, but using body of XHR which has failed. Only works with error 422. If the XHR returns and error and you do not supply a refresh-on-error, nothing is changed
 * `data-tg-full-refresh-on-error-except`: (optional) Replaces body except for specified refresh keys, using the body of the XHR which has failed.  Only works with error 422
 * `data-tg-remote-once`: (optional) The action will only be performed once. Removes `data-tg-remote-method` and `data-tg-remote-once` from element after consumption
-* `data-tg-full-refresh`: Rather than using the content of the XHR response for partial page replacement, a full page refresh is performed. If `data-tg-refresh-on-success` is defined, the page will be reloaded on these keys. If `data-tg-refresh-on-success` is not defined, a full page refresh is performed. Defaults to true if neither refresh-on-success nor refresh-on-error are provided
+* `data-tg-full-refresh`: Rather than using the content of the XHR response for partial page replacement, a full page refresh is performed. If `data-tg-refresh-on-success` or `data-tg-refresh-on-error` is defined, the page will be reloaded on those keys. If both `data-tg-refresh-on-success` and `data-tg-refresh-on-error` are not defined, a full page refresh is performed. Defaults to true if neither refresh-on-success nor refresh-on-error are provided
 * `data-tg-remote-norefresh`: Prevents `Page.refresh()` from being called, allowing methods to be executed without updating client state
 
 Note that as `data-tg-refresh-on-*` pertains to partial refreshes and `data-tg-full-refresh-on-*-except` pertains to full refreshes, they are incompatible with each other and should not be combined.
@@ -125,7 +125,7 @@ Post to a remote form:
 * `turbograft:remote:always`: Always fires when XHR is complete
 * `turbograft:remote:success`: Always fires when XHR was successful
 * `turbograft:remote:fail`: Always fires when XHR failed
-* `turbograft:remote:fail:unhandled`: Fires after `turbograft:remote:fail`, but when no partial replacement with refresh-on-error was performed (because no `data-tg-refresh-on-error` was supplied)
+* `turbograft:remote:fail:unhandled`: Fires after `turbograft:remote:fail`, but when no partial replacement with refresh-on-error was performed (because no `data-tg-refresh-on-error` was supplied or because `data-tg-remote-norefresh` was present)
 
 Each event also is sent with a copy of the XHR, as well as a reference to the element that initated the `data-tg-remote-method`.
 

--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -153,14 +153,22 @@ class TurboGraft.Remote
       initiator: @initiator
       xhr: xhr
 
-    if @refreshOnError
-      Page.refresh
-        response: xhr
-        onlyKeys: @refreshOnError
-    else if @refreshOnErrorExcept
-      Page.refresh
-        response: xhr
-        exceptKeys: @refreshOnErrorExcept
-    else
+    if TurboGraft.hasTGAttribute(@initiator, 'tg-remote-norefresh')
       triggerEventFor 'turbograft:remote:fail:unhandled', @initiator,
         xhr: xhr
+    else
+      if @opts.fullRefresh && @refreshOnError
+        Page.refresh(onlyKeys: @refreshOnError)
+      else if @opts.fullRefresh
+        Page.refresh()
+      else if @refreshOnError
+        Page.refresh
+          response: xhr
+          onlyKeys: @refreshOnError
+      else if @refreshOnErrorExcept
+        Page.refresh
+          response: xhr
+          exceptKeys: @refreshOnErrorExcept
+      else
+        triggerEventFor 'turbograft:remote:fail:unhandled', @initiator,
+          xhr: xhr

--- a/test/javascripts/page_test.coffee
+++ b/test/javascripts/page_test.coffee
@@ -22,7 +22,7 @@ describe 'Page', ->
         url: '/foo'
 
       assert @visitStub.calledOnce
-      assert @visitStub.calledWith "/foo", { partialReplace: true, onlyKeys: undefined }
+      assert @visitStub.calledWith "/foo", { url: '/foo', partialReplace: true }
 
     it 'with opts.queryParams', ->
       Page.refresh

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -299,7 +299,7 @@ describe 'Remote', ->
       assert @refreshStub.calledWith
         onlyKeys: ['a', 'b', 'c']
 
-    it 'XHR=200: will trigger Page.refresh with no arguments when neither refresh-on-success nor refresh-on-error are provided', ->
+    it 'XHR=200: will trigger Page.refresh with no arguments when full-refresh is present and refresh-on-success is not provided', ->
       server = sinon.fakeServer.create();
       server.respondWith("POST", "/foo/bar",
             [200, { "Content-Type": "text/html" },
@@ -334,7 +334,43 @@ describe 'Remote', ->
 
       assert.equal 0, @refreshStub.callCount
 
-    it 'will trigger Page.refresh using XHR and refresh-on-error', ->
+    it 'XHR=422: will trigger Page.refresh using XHR and refresh-on-error', ->
+      server = sinon.fakeServer.create();
+      server.respondWith("POST", "/foo/bar",
+            [422, { "Content-Type": "text/html" },
+             '<div id="foo" refresh="foo">Error occured</div>']);
+      remote = new TurboGraft.Remote
+        httpRequestType: "POST"
+        httpUrl: "/foo/bar"
+        refreshOnError: "a b c"
+      , @initiating_target
+      remote.submit()
+
+      server.respond()
+
+      assert @refreshStub.calledWith
+        response: sinon.match.has('responseText', '<div id="foo" refresh="foo">Error occured</div>')
+        onlyKeys: ['a', 'b', 'c']
+
+    it 'XHR=422: will trigger Page.refresh using XHR and refresh-on-error-except', ->
+      server = sinon.fakeServer.create();
+      server.respondWith("POST", "/foo/bar",
+            [422, { "Content-Type": "text/html" },
+             '<div id="foo" refresh="foo">Error occured</div>']);
+      remote = new TurboGraft.Remote
+        httpRequestType: "POST"
+        httpUrl: "/foo/bar"
+        refreshOnErrorExcept: "a b c"
+      , @initiating_target
+      remote.submit()
+
+      server.respond()
+
+      assert @refreshStub.calledWith
+        response: sinon.match.has('responseText', '<div id="foo" refresh="foo">Error occured</div>')
+        exceptKeys: ['a', 'b', 'c']
+
+    it 'XHR=422: will trigger Page.refresh with refresh-on-error when full-refresh is provided', ->
       server = sinon.fakeServer.create();
       server.respondWith("POST", "/foo/bar",
             [422, { "Content-Type": "text/html" },
@@ -350,10 +386,9 @@ describe 'Remote', ->
       server.respond()
 
       assert @refreshStub.calledWith
-        response: sinon.match.has('responseText', '<div id="foo" refresh="foo">Error occured</div>')
         onlyKeys: ['a', 'b', 'c']
 
-    it 'will trigger Page.refresh using XHR and refresh-on-error-except', ->
+    it 'XHR=422: will not trigger Page.refresh if no refresh-on-error is present', ->
       server = sinon.fakeServer.create();
       server.respondWith("POST", "/foo/bar",
             [422, { "Content-Type": "text/html" },
@@ -361,25 +396,41 @@ describe 'Remote', ->
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
-        refreshOnErrorExcept: "a b c"
+      , @initiating_target
+      remote.submit()
+
+      server.respond()
+
+      assert.equal 0, @refreshStub.callCount
+
+    it 'XHR=422: will trigger Page.refresh with no arguments when full-refresh is present and refresh-on-error is not provided', ->
+      server = sinon.fakeServer.create();
+      server.respondWith("POST", "/foo/bar",
+            [422, { "Content-Type": "text/html" },
+             '<div id="foo" refresh="foo">Error occured</div>']);
+      remote = new TurboGraft.Remote
+        httpRequestType: "POST"
+        httpUrl: "/foo/bar"
         fullRefresh: true
       , @initiating_target
       remote.submit()
 
       server.respond()
 
-      assert @refreshStub.calledWith
-        response: sinon.match.has('responseText', '<div id="foo" refresh="foo">Error occured</div>')
-        exceptKeys: ['a', 'b', 'c']
+      assert.equal 1, @refreshStub.callCount
+      assert.equal 0, @refreshStub.args[0].length
 
-    it 'will not trigger Page.refresh if no refresh-on-error is present', ->
+    it 'XHR=422: will not trigger Page.refresh when tg-remote-norefresh is present on the initiator', ->
       server = sinon.fakeServer.create();
       server.respondWith("POST", "/foo/bar",
             [422, { "Content-Type": "text/html" },
              '<div id="foo" refresh="foo">Error occured</div>']);
+
+      @initiating_target.setAttribute("tg-remote-norefresh", true)
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
+        fullRefresh: true
       , @initiating_target
       remote.submit()
 


### PR DESCRIPTION
**This PR adds:**
 - The ability for `full-refresh` to behave the same way on Error (422) as it does on Success (200):
   - Without the presence of `refresh-on-error`, `full-refresh` will now perform a full page refresh.
   - With the presence of `refresh-on-error`, `full-refresh` will perform a partial page replacement using `onlyKeys: @refreshOnError`
   - This is in line with how `full-refresh` behaves with `refresh-on-success`.
 - `tg-remote-norefresh` now prevents `Page.refresh` on Error (422).

## Bonus
I've gone ahead and fixed the failing `Page.refresh` test on master. All tests are 🍏 :
![image](https://cloud.githubusercontent.com/assets/2578036/15410170/57fba520-1de6-11e6-9881-33b16332cd66.png)

however builds were broken:
![image](https://cloud.githubusercontent.com/assets/2578036/15410139/2ed8ae4a-1de6-11e6-864a-727b0ad46a8b.png)

![image](https://cloud.githubusercontent.com/assets/2578036/15410127/19d77be8-1de6-11e6-99d6-be0081eaa1a8.png)

This was due to `rack` requiring ruby version `>=2.2.0`.

After dropping support for ruby versions `<2.2.0` the builds all pass and everything is 🐸 

For review:
@qq99 @dfmcphee @nwtn 