### PR TITLE
Bind this.onError for XHR requests in TurboGraft.Remote

### DIFF
--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -116,7 +116,7 @@ class TurboGraft.Remote
       enabledInputs.push(input)
     enabledInputs
 
-  onSuccess: (ev) ->
+  onSuccess: (ev) =>
     @opts.success?()
 
     xhr = ev.target
@@ -145,7 +145,7 @@ class TurboGraft.Remote
         Page.refresh
           response: xhr
 
-  onError: (ev) ->
+  onError: (ev) =>
     @opts.fail?()
 
     xhr = ev.target

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -8,7 +8,7 @@ describe 'Remote', ->
   describe 'HTTP methods', ->
 
     it 'will send a GET with _method=GET', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       remote = new TurboGraft.Remote
         httpRequestType: "GET"
         httpUrl: "/foo/bar"
@@ -20,7 +20,7 @@ describe 'Remote', ->
       assert.equal "GET", request.method
 
     it 'will send a POST with _method=POST', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -32,7 +32,7 @@ describe 'Remote', ->
       assert.equal "POST", request.method
 
     it 'will send a POST with _method=PUT', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       remote = new TurboGraft.Remote
         httpRequestType: "PUT"
         httpUrl: "/foo/bar"
@@ -44,7 +44,7 @@ describe 'Remote', ->
       assert.equal "POST", request.method
 
     it 'will send a POST with _method=PATCH', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       remote = new TurboGraft.Remote
         httpRequestType: "PATCH"
         httpUrl: "/foo/bar"
@@ -56,7 +56,7 @@ describe 'Remote', ->
       assert.equal "POST", request.method
 
     it 'will send a POST with _method=DELETE', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       remote = new TurboGraft.Remote
         httpRequestType: "DELETE"
         httpUrl: "/foo/bar"
@@ -112,7 +112,7 @@ describe 'Remote', ->
         assert.equal "/foo/bar", ev.originalEvent.data.xhr.url
         done()
 
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -124,7 +124,7 @@ describe 'Remote', ->
         assert.equal "/foo/bar", ev.originalEvent.data.xhr.url
         done()
 
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -139,10 +139,10 @@ describe 'Remote', ->
         assert.equal "/foo/bar", ev.originalEvent.data.xhr.url
         done()
 
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [200, { "Content-Type": "text/html" },
-             '<div>Hey there</div>']);
+             '<div>Hey there</div>'])
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -162,10 +162,10 @@ describe 'Remote', ->
         assert.equal "/foo/bar", ev.originalEvent.data.xhr.url
         done()
 
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [422, { "Content-Type": "text/html" },
-             '<div id="foo" refresh="foo">Error occured</div>']);
+             '<div id="foo" refresh="foo">Error occured</div>'])
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -183,10 +183,10 @@ describe 'Remote', ->
         assert.equal "/foo/bar", ev.originalEvent.data.xhr.url
         done()
 
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [422, { "Content-Type": "text/html" },
-             '<div id="foo" refresh="foo">Error occured</div>']);
+             '<div id="foo" refresh="foo">Error occured</div>'])
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -200,10 +200,10 @@ describe 'Remote', ->
         assert.equal "/foo/bar", ev.originalEvent.data.xhr.url
         done()
 
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [200, { "Content-Type": "text/html" },
-             '<div>Hey there</div>']);
+             '<div>Hey there</div>'])
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -217,10 +217,10 @@ describe 'Remote', ->
         assert.equal "/foo/bar", ev.originalEvent.data.xhr.url
         done()
 
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [500, { "Content-Type": "text/html" },
-             '<div id="foo" refresh="foo">Error occured</div>']);
+             '<div id="foo" refresh="foo">Error occured</div>'])
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -230,10 +230,10 @@ describe 'Remote', ->
       server.respond()
 
     it 'XHR=200: will trigger Page.refresh using XHR only', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [200, { "Content-Type": "text/html" },
-             '<div>Hey there</div>']);
+             '<div>Hey there</div>'])
 
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
@@ -246,10 +246,10 @@ describe 'Remote', ->
         response: sinon.match.has('responseText', '<div>Hey there</div>')
 
     it 'XHR=200: will trigger Page.refresh using XHR and refresh-on-success', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [200, { "Content-Type": "text/html" },
-             '<div>Hey there</div>']);
+             '<div>Hey there</div>'])
 
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
@@ -264,10 +264,10 @@ describe 'Remote', ->
         onlyKeys: ['a', 'b', 'c']
 
     it 'XHR=200: will trigger Page.refresh using XHR and refresh-on-success-except', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [200, { "Content-Type": "text/html" },
-             '<div>Hey there</div>']);
+             '<div>Hey there</div>'])
 
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
@@ -282,10 +282,10 @@ describe 'Remote', ->
         exceptKeys: ['a', 'b', 'c']
 
     it 'XHR=200: will trigger Page.refresh with refresh-on-success when full-refresh is provided', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [200, { "Content-Type": "text/html" },
-             '<div>Hey there</div>']);
+             '<div>Hey there</div>'])
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -300,10 +300,10 @@ describe 'Remote', ->
         onlyKeys: ['a', 'b', 'c']
 
     it 'XHR=200: will trigger Page.refresh with no arguments when full-refresh is present and refresh-on-success is not provided', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [200, { "Content-Type": "text/html" },
-             '<div>Hey there</div>']);
+             '<div>Hey there</div>'])
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -317,10 +317,10 @@ describe 'Remote', ->
       assert.equal 0, @refreshStub.args[0].length
 
     it 'XHR=200: will not trigger Page.refresh when tg-remote-norefresh is present on the initiator', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [200, { "Content-Type": "text/html" },
-             '<div>Hey there</div>']);
+             '<div>Hey there</div>'])
 
       @initiating_target.setAttribute("tg-remote-norefresh", true)
       remote = new TurboGraft.Remote
@@ -335,10 +335,10 @@ describe 'Remote', ->
       assert.equal 0, @refreshStub.callCount
 
     it 'XHR=422: will trigger Page.refresh using XHR and refresh-on-error', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [422, { "Content-Type": "text/html" },
-             '<div id="foo" refresh="foo">Error occured</div>']);
+             '<div id="foo" refresh="foo">Error occured</div>'])
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -353,10 +353,10 @@ describe 'Remote', ->
         onlyKeys: ['a', 'b', 'c']
 
     it 'XHR=422: will trigger Page.refresh using XHR and refresh-on-error-except', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [422, { "Content-Type": "text/html" },
-             '<div id="foo" refresh="foo">Error occured</div>']);
+             '<div id="foo" refresh="foo">Error occured</div>'])
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -371,10 +371,10 @@ describe 'Remote', ->
         exceptKeys: ['a', 'b', 'c']
 
     it 'XHR=422: will trigger Page.refresh with refresh-on-error when full-refresh is provided', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [422, { "Content-Type": "text/html" },
-             '<div id="foo" refresh="foo">Error occured</div>']);
+             '<div id="foo" refresh="foo">Error occured</div>'])
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -389,10 +389,10 @@ describe 'Remote', ->
         onlyKeys: ['a', 'b', 'c']
 
     it 'XHR=422: will not trigger Page.refresh if no refresh-on-error is present', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [422, { "Content-Type": "text/html" },
-             '<div id="foo" refresh="foo">Error occured</div>']);
+             '<div id="foo" refresh="foo">Error occured</div>'])
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -404,10 +404,10 @@ describe 'Remote', ->
       assert.equal 0, @refreshStub.callCount
 
     it 'XHR=422: will trigger Page.refresh with no arguments when full-refresh is present and refresh-on-error is not provided', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [422, { "Content-Type": "text/html" },
-             '<div id="foo" refresh="foo">Error occured</div>']);
+             '<div id="foo" refresh="foo">Error occured</div>'])
       remote = new TurboGraft.Remote
         httpRequestType: "POST"
         httpUrl: "/foo/bar"
@@ -421,10 +421,10 @@ describe 'Remote', ->
       assert.equal 0, @refreshStub.args[0].length
 
     it 'XHR=422: will not trigger Page.refresh when tg-remote-norefresh is present on the initiator', ->
-      server = sinon.fakeServer.create();
+      server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [422, { "Content-Type": "text/html" },
-             '<div id="foo" refresh="foo">Error occured</div>']);
+             '<div id="foo" refresh="foo">Error occured</div>'])
 
       @initiating_target.setAttribute("tg-remote-norefresh", true)
       remote = new TurboGraft.Remote


### PR DESCRIPTION
I have a feeling this is causing https://bugsnag.com/shopify/shopify-js/errors/5666f3c78f2356495b6fe53f?filters%5Bevent.since%5D%5B%5D=30d.

r @qq99 
cc @arapehl 
