### PR TITLE
Add minimum Ruby version

### DIFF
--- a/lib/turbograft.rb
+++ b/lib/turbograft.rb
@@ -35,10 +35,8 @@ module TurboGraft
       end
 
       ActiveSupport.on_load(:action_view) do
-        (ActionView::RoutingUrlFor rescue ActionView::Helpers::UrlHelper).module_eval do
-          prepend XHRUrlFor
-        end
-      end unless RUBY_VERSION =~ /^1\.8/
+        (ActionView::RoutingUrlFor rescue ActionView::Helpers::UrlHelper).prepend(XHRUrlFor)
+      end
     end
   end
 end

--- a/turbograft.gemspec
+++ b/turbograft.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '~> 2.1'
+
   spec.add_dependency "coffee-rails"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
This PR bumps the Ruby dependency of TG to Ruby 2.0. This is required for `prepend`.

It also addresses [@phoet's comment](https://github.com/Shopify/turbograft/pull/121#discussion_r74129271). 

