### PR TITLE
prepend is public since 2.1

### DIFF
--- a/lib/turbograft.rb
+++ b/lib/turbograft.rb
@@ -35,8 +35,7 @@ module TurboGraft
       end
 
       ActiveSupport.on_load(:action_view) do
-        (ActionView::RoutingUrlFor rescue ActionView::Helpers::UrlHelper).module_eval do
-          prepend XHRUrlFor
+        ActionView::RoutingUrlFor.prepend XHRUrlFor
         end
       end unless RUBY_VERSION =~ /^1\.8/
     end


### PR DESCRIPTION
since the method has been made public, we can invoke it without any `moduel_eval`ing

refs https://github.com/Shopify/turbograft/pull/121#discussion_r74129271