### PR TITLE
add js test info to readme and add environment var for teaspoon driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,5 +189,5 @@ document.addEventListener 'page:after-node-removed', (event) ->
 ## Testing
 
 - `./server` and visit http://localhost:3000/teaspoon to run the JS test suite in the browser
-- `bundle exec teaspoon` will run the JS test suite from the command line (note: this uses phantomjs by default, but can be configured using the TEASPOON_DRIVER environment variable)
+- `bundle exec teaspoon` will run the JS test suite from the command line (note: this uses selenium by default, but can be configured using the TEASPOON_DRIVER environment variable)
 - `bundle exec rake test` to run the browser test suite

--- a/README.md
+++ b/README.md
@@ -189,5 +189,5 @@ document.addEventListener 'page:after-node-removed', (event) ->
 ## Testing
 
 - `./server` and visit http://localhost:3000/teaspoon to run the JS test suite in the browser
-- `bundle exec teaspoon` will run the JS test suite from the command line (note: this uses selenium by default, but can be configured using the TEASPOON_DRIVER environment variable)
+- `bundle exec teaspoon` will run the JS test suite from the command line. Uses Selenium by default, but can be configured using the TEASPOON_DRIVER environment variable
 - `bundle exec rake test` to run the browser test suite

--- a/README.md
+++ b/README.md
@@ -188,5 +188,6 @@ document.addEventListener 'page:after-node-removed', (event) ->
 
 ## Testing
 
-- `./server` and visit http://localhost:3000/teaspoon to run the JS test suite
+- `./server` and visit http://localhost:3000/teaspoon to run the JS test suite in the browser
+- `bundle exec teaspoon` will run the JS test suite from the command line. (note: this uses [Selenium](https://github.com/SeleniumHQ/selenium), you'll need a [compatible version of firefox.](http://stackoverflow.com/questions/37693106/selenium-2-53-not-working-on-firefox-47))
 - `bundle exec rake test` to run the browser test suite

--- a/README.md
+++ b/README.md
@@ -189,5 +189,5 @@ document.addEventListener 'page:after-node-removed', (event) ->
 ## Testing
 
 - `./server` and visit http://localhost:3000/teaspoon to run the JS test suite in the browser
-- `bundle exec teaspoon` will run the JS test suite from the command line. (note: this uses [Selenium](https://github.com/SeleniumHQ/selenium), you'll need a [compatible version of firefox.](http://stackoverflow.com/questions/37693106/selenium-2-53-not-working-on-firefox-47))
+- `bundle exec teaspoon` will run the JS test suite from the command line (note: this uses phantomjs by default, but can be configured using the TEASPOON_DRIVER environment variable)
 - `bundle exec rake test` to run the browser test suite

--- a/test/teaspoon_env.rb
+++ b/test/teaspoon_env.rb
@@ -5,7 +5,7 @@ unless defined?(Rails)
 end
 
 Teaspoon.configure do |config|
-  config.driver = "selenium"
+  config.driver = ENV['TEASPOON_DRIVER'] || "phantomjs"
   config.mount_at = "/teaspoon"
   config.root = TurboGraft::Engine.root
   config.asset_paths = ["test/javascripts"]

--- a/test/teaspoon_env.rb
+++ b/test/teaspoon_env.rb
@@ -5,7 +5,7 @@ unless defined?(Rails)
 end
 
 Teaspoon.configure do |config|
-  config.driver = ENV['TEASPOON_DRIVER'] || "phantomjs"
+  config.driver = ENV['TEASPOON_DRIVER'] || "selenium"
   config.mount_at = "/teaspoon"
   config.root = TurboGraft::Engine.root
   config.asset_paths = ["test/javascripts"]


### PR DESCRIPTION
This PR adds more information about running tests to the readme.

This PR also adds a link to some troubleshooting information about why selenium will probably explode when you try to do this, and how to not have it explode.