### PR TITLE
Replaced all assert while loops from selenium tests with proper Capybara assertions

### DIFF
--- a/test/browser/full_page_refresh_test.rb
+++ b/test/browser/full_page_refresh_test.rb
@@ -40,28 +40,18 @@ class FullPageRefreshTest < ActionDispatch::IntegrationTest
 
   test "going to a URL that will error 500, and hitting the browser back button, we see the correct page (and not the 500)" do
     click_link "I will throw an error 500"
-    has_text = false
-    while !has_text
-      has_text = page.assert_text('Error 500!')
-      sleep 1
-    end
-    assert_not_equal "Sample Turbograft Application", page.title
+    page.assert_no_title("Sample Turbograft Application")
     page.execute_script 'window.history.back()'
     page.assert_no_text('Error 500!')
-    assert_equal "Sample Turbograft Application", page.title
+    page.assert_title("Sample Turbograft Application")
   end
 
   test "going to a URL that will error 404, and hitting the browser back button, we see the correct page (and not the 404)" do
     click_link "I will throw an error 404"
-    has_text = false
-    while !has_text
-      has_text = page.assert_text('Error 404!')
-      sleep 1
-    end
-    assert_not_equal "Sample Turbograft Application", page.title
+    page.assert_no_title("Sample Turbograft Application")
     page.execute_script 'window.history.back()'
     page.assert_no_text('Error 404!')
-    assert_equal "Sample Turbograft Application", page.title
+    page.assert_title("Sample Turbograft Application")
   end
 
   test "data-tg-static preserves client-side state of innards on full refresh, but will replaces contents if we specifically data-tg-partially-refresh a section inside of it" do
@@ -69,10 +59,7 @@ class FullPageRefreshTest < ActionDispatch::IntegrationTest
     click_link "Perform a full page refresh"
     assert_equal "data-tg-static innards", find_field("badgeinput").value
     click_link "Perform a partial page refresh and refresh the navigation section"
-    while !page.has_content?
-      sleep 500
-    end
-    assert_equal "", find_field("badgeinput").value
+    find_field("badgeinput").assert_no_text("data-tg-static innards")
   end
 
   test "data-tg-refresh-always will always refresh the annotated nodes, regardless of refresh type" do

--- a/test/browser/legacy_full_page_refresh_test.rb
+++ b/test/browser/legacy_full_page_refresh_test.rb
@@ -8,22 +8,6 @@ class LegacyPagesFullPageRefreshTest < ActionDispatch::IntegrationTest
     visit "/legacy_pages/1"
   end
 
-  def wait_until_page_has(content)
-    finished_navigation = false
-    while !finished_navigation
-      finished_navigation = page.has_content?(content)
-      sleep 1
-    end
-  end
-
-  def wait_until_page_does_not_have(content)
-    finished_navigation = false
-    while !finished_navigation
-      finished_navigation = !page.has_content?(content)
-      sleep 1
-    end
-  end
-
   test "will strip noscript tags" do
     click_link "Perform a full navigation to learn more"
     refute page.has_selector?("noscript") # this test should pass, I think
@@ -56,14 +40,13 @@ class LegacyPagesFullPageRefreshTest < ActionDispatch::IntegrationTest
 
   test "going to a URL that should error 500" do
     click_link "I will throw an error 500"
-    wait_until_page_has("Error 500!")
 
-    assert_not_equal "Sample Turbograft Application", page.title
+    page.assert_no_title("Sample Turbograft Application")
   end
 
   test "going to a URL that will error 500, and hitting the browser back button, we see the correct page (and not the 500)" do
     click_link "I will throw an error 500"
-    wait_until_page_has("Error 500!")
+    page.assert_text("Error 500!")
     page.execute_script 'window.history.back()'
 
     page.assert_no_text('Error 500!')
@@ -72,14 +55,14 @@ class LegacyPagesFullPageRefreshTest < ActionDispatch::IntegrationTest
 
   test "going to a URL that should error 404" do
     click_link "I will throw an error 404"
-    wait_until_page_has("Error 404!")
+    page.assert_text("Error 404!")
 
     assert_not_equal "Sample Turbograft Application", page.title
   end
 
   test "going to a URL that will error 404, and hitting the browser back button, we see the correct page (and not the 404)" do
     click_link "I will throw an error 404"
-    wait_until_page_has("Error 404!")
+    page.assert_text("Error 404!")
     page.execute_script 'window.history.back()'
 
     page.assert_no_text('Error 404!')
@@ -91,7 +74,7 @@ class LegacyPagesFullPageRefreshTest < ActionDispatch::IntegrationTest
     click_link "Perform a full page refresh"
     assert_equal "tg-static innards", find_field("badgeinput").value
     click_link "Perform a partial page refresh and refresh the navigation section"
-    wait_until_page_does_not_have("tg-static innards")
+    find_field("badgeinput").assert_no_text("tg-static innards")
     assert_equal "", find_field("badgeinput").value
   end
 
@@ -102,7 +85,7 @@ class LegacyPagesFullPageRefreshTest < ActionDispatch::IntegrationTest
     assert_equal "", find_field("badgeinput2").value
     page.fill_in 'badgeinput2', :with => 'some innards 555'
     click_link "Perform a partial page refresh and refresh the navigation section"
-    wait_until_page_does_not_have("some innards 555")
+    find_field("badgeinput2").assert_no_text("some innards 555")
     page.assert_no_text "some innards 555"
     assert_equal "", find_field("badgeinput2").value
   end

--- a/test/browser/legacy_partial_page_refresh_test.rb
+++ b/test/browser/legacy_partial_page_refresh_test.rb
@@ -16,7 +16,7 @@ class LegacyPagesPartialPageRefreshTest < ActionDispatch::IntegrationTest
     assert random_b
 
     click_link "Go to next page via partial refresh"
-    assert page.has_content?("page 2")
+    page.assert_text("page 2")
     assert_equal random_a, find('#random-number-a').text
     assert_equal random_b, find('#random-number-b').text
   end
@@ -29,19 +29,19 @@ class LegacyPagesPartialPageRefreshTest < ActionDispatch::IntegrationTest
     assert random_b
 
     click_button "Refresh Section A"
-    assert page.has_content?("page 1")
+    page.assert_text("page 1")
     assert_not_equal random_a, find('#random-number-a').text
     assert_equal random_b, find('#random-number-b').text
 
     random_a = find('#random-number-a').text
     click_button "Refresh Section B"
-    assert page.has_content?("page 1")
+    page.assert_text("page 1")
     assert_equal random_a, find('#random-number-a').text
     assert_not_equal random_b, find('#random-number-b').text
 
     random_b = find('#random-number-b').text
     click_button "Refresh Section A and B"
-    assert page.has_content?("page 1")
+    page.assert_text("page 1")
     assert_not_equal random_a, find('#random-number-a').text
     assert_not_equal random_b, find('#random-number-b').text
   end
@@ -52,7 +52,7 @@ class LegacyPagesPartialPageRefreshTest < ActionDispatch::IntegrationTest
 
     click_button "Post via XHR and see X-XHR-Redirected-To"
 
-    assert page.has_content?("page 321")
+    page.assert_text("page 321")
 
     page.document.synchronize do
       throw "not ready" unless current_url != old_location
@@ -66,7 +66,7 @@ class LegacyPagesPartialPageRefreshTest < ActionDispatch::IntegrationTest
     click_link "tg-remote GET to response of 200"
 
     new_location = current_url
-    refute page.has_content?("Page 1")
+    page.assert_no_text("Page 1")
     assert_equal new_location, old_location
   end
 
@@ -79,7 +79,7 @@ class LegacyPagesPartialPageRefreshTest < ActionDispatch::IntegrationTest
     click_link "tg-remote GET to response of 200 with full-refresh-on-success-except"
 
     new_location = current_url
-    refute page.has_content?("Page 1")
+    page.assert_no_text("Page 1")
     assert_equal random_a, find('#random-number-a').text
     assert_equal new_location, old_location
   end
@@ -91,7 +91,7 @@ class LegacyPagesPartialPageRefreshTest < ActionDispatch::IntegrationTest
     click_link "tg-remote GET to response of 422"
 
     new_location = current_url
-    assert page.has_content?("Error 422!")
+    page.assert_text("Error 422!")
     assert_equal new_location, old_location
   end
 
@@ -102,45 +102,45 @@ class LegacyPagesPartialPageRefreshTest < ActionDispatch::IntegrationTest
     page.fill_in 'foopost', :with => 'some text'
     click_button "Submit tg-remote POST"
 
-    refute page.has_content?("Please supply a foo!")
+    page.assert_no_text("Please supply a foo!")
     assert page.has_content?("Thanks for the foo! We'll consider it.")
   end
 
   test "tg-remote on a form with get" do
     click_button "Submit tg-remote GET"
-    assert page.has_content?("Please supply a foo!")
+    page.assert_text("Please supply a foo!")
 
     page.fill_in 'fooget', :with => 'some text'
     click_button "Submit tg-remote GET"
 
-    refute page.has_content?("Please supply a foo!")
+    page.assert_no_text("Please supply a foo!")
     assert page.has_content?("We found no results for some text :(")
   end
 
   test "tg-remote on a form with patch" do
     click_button "Submit tg-remote PATCH"
-    assert page.has_content?("Thanks, we got your patch.")
+    page.assert_text("Thanks, we got your patch.")
   end
 
   test "tg-remote on a form with put" do
     click_button "Submit tg-remote PUT"
-    assert page.has_content?("Please supply a foo!")
+    page.assert_text("Please supply a foo!")
 
     page.fill_in 'fooput', :with => 'some text'
     click_button "Submit tg-remote PUT"
 
-    refute page.has_content?("Please supply a foo!")
+    page.assert_no_text("Please supply a foo!")
     assert page.has_content?("Thanks, we replaced your foo with a new one.")
   end
 
   test "tg-remote on a form with delete" do
     click_button "Submit tg-remote DELETE"
-    assert page.has_content?("Please confirm that you want to delete this foo.")
+    page.assert_text("Please confirm that you want to delete this foo.")
 
     page.check 'foodelete'
     click_button "Submit tg-remote DELETE"
 
-    refute page.has_content?("Please confirm that you want to delete this foo.")
+    page.assert_no_text("Please confirm that you want to delete this foo.")
     assert page.has_content?("Your foo has been destroyed.")
   end
 end

--- a/test/browser/partial_page_refresh_test.rb
+++ b/test/browser/partial_page_refresh_test.rb
@@ -16,7 +16,7 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     assert random_b
 
     click_link "Go to next page via partial refresh"
-    assert page.has_content?("page 2")
+    page.assert_text("page 2")
     assert_equal random_a, find('#random-number-a').text
     assert_equal random_b, find('#random-number-b').text
   end
@@ -29,19 +29,19 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     assert random_b
 
     click_button "Refresh Section A"
-    assert page.has_content?("page 1")
+    page.assert_text("page 1")
     assert_not_equal random_a, find('#random-number-a').text
     assert_equal random_b, find('#random-number-b').text
 
     random_a = find('#random-number-a').text
     click_button "Refresh Section B"
-    assert page.has_content?("page 1")
+    page.assert_text("page 1")
     assert_equal random_a, find('#random-number-a').text
     assert_not_equal random_b, find('#random-number-b').text
 
     random_b = find('#random-number-b').text
     click_button "Refresh Section A and B"
-    assert page.has_content?("page 1")
+    page.assert_text("page 1")
     assert_not_equal random_a, find('#random-number-a').text
     assert_not_equal random_b, find('#random-number-b').text
   end
@@ -52,7 +52,7 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
 
     click_button "Post via XHR and see X-XHR-Redirected-To"
 
-    assert page.has_content?("page 321")
+    page.assert_text("page 321")
 
     page.document.synchronize do
       throw "not ready" unless current_url != old_location
@@ -66,7 +66,7 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     click_link "data-tg-remote GET to response of 200"
 
     new_location = current_url
-    refute page.has_content?("Page 1")
+    page.assert_no_text("Page 1")
     assert_equal new_location, old_location
   end
 
@@ -79,7 +79,7 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     click_link "data-tg-remote GET to response of 200 with data-tg-full-refresh-on-success-except"
 
     new_location = current_url
-    refute page.has_content?("Page 1")
+    page.assert_no_text("Page 1")
     assert_equal random_a, find('#random-number-a').text
     assert_equal new_location, old_location
   end
@@ -91,7 +91,7 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     click_link "data-tg-remote GET to response of 422"
 
     new_location = current_url
-    assert page.has_content?("Error 422!")
+    page.assert_text("Error 422!")
     assert_equal new_location, old_location
   end
 
@@ -102,45 +102,45 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
     page.fill_in 'foopost', :with => 'some text'
     click_button "Submit data-tg-remote POST"
 
-    refute page.has_content?("Please supply a foo!")
+    page.assert_no_text("Please supply a foo!")
     assert page.has_content?("Thanks for the foo! We'll consider it.")
   end
 
   test "data-tg-remote on a form with get" do
     click_button "Submit data-tg-remote GET"
-    assert page.has_content?("Please supply a foo!")
+    page.assert_text("Please supply a foo!")
 
     page.fill_in 'fooget', :with => 'some text'
     click_button "Submit data-tg-remote GET"
 
-    refute page.has_content?("Please supply a foo!")
+    page.assert_no_text("Please supply a foo!")
     assert page.has_content?("We found no results for some text :(")
   end
 
   test "data-tg-remote on a form with patch" do
     click_button "Submit data-tg-remote PATCH"
-    assert page.has_content?("Thanks, we got your patch.")
+    page.assert_text("Thanks, we got your patch.")
   end
 
   test "data-tg-remote on a form with put" do
     click_button "Submit data-tg-remote PUT"
-    assert page.has_content?("Please supply a foo!")
+    page.assert_text("Please supply a foo!")
 
     page.fill_in 'fooput', :with => 'some text'
     click_button "Submit data-tg-remote PUT"
 
-    refute page.has_content?("Please supply a foo!")
+    page.assert_no_text("Please supply a foo!")
     assert page.has_content?("Thanks, we replaced your foo with a new one.")
   end
 
   test "data-tg-remote on a form with delete" do
     click_button "Submit data-tg-remote DELETE"
-    assert page.has_content?("Please confirm that you want to delete this foo.")
+    page.assert_text("Please confirm that you want to delete this foo.")
 
     page.check 'foodelete'
     click_button "Submit data-tg-remote DELETE"
 
-    refute page.has_content?("Please confirm that you want to delete this foo.")
+    page.assert_no_text("Please confirm that you want to delete this foo.")
     assert page.has_content?("Your foo has been destroyed.")
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ require 'rails/test_help'
 
 Capybara.app = Example::Application
 Capybara.current_driver = :selenium
-Capybara.default_wait_time = 2
+Capybara.default_max_wait_time = 2
 
 Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new(color: true))
 


### PR DESCRIPTION
There were a couple cases of
```ruby
has_text = false
while !has_text
  has_text = page.assert_text("something")
  sleep 1
assert_equal something, 'something'
```
in our test suite and they were causing tests to flake in CI since the `while` loop can sometimes pass the assertion on the first iteration, or fail numerous times in subsequent assertions before exiting the loop.

We fixed them to use `has_text` instead of `assert_text` in https://github.com/Shopify/turbograft/pull/123 and this prevented flakiness since the test would not fail when `has_text` returned false.

However @GoodForOneFare pointed out that Capybara actually has the [built in behaviour](https://github.com/jnicklas/capybara/blob/master/README.md#asynchronous-javascript-ajax-and-friends) to keep repeating a failing assertion for 2 seconds before it gives up and actually produces a failure. The 2 second grace period can be adjusted in the config or on a per test basis by passing in a `wait` argument to the assertion.

This PR leverages these Capybara assertions to remove the `while` loops completely from all of our tests and the symptom of flakiness.

For review:
@Shopify/tnt @TheMallen 