### PR TITLE
Fix safari no styles

### DIFF
--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -26,8 +26,7 @@ updateScriptTags = (activeDocument, newScripts, callback) ->
   )
 
 extractTrackedAssets = (doc) ->
-  for node in doc.head.children when node.dataset.turbolinksTrack?
-    node
+  return [].slice.call(doc.querySelectorAll('[data-turbolinks-track]'))
 
 filterForNodeType = (nodeType) ->
   (node) -> node.nodeName == nodeType

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -26,7 +26,7 @@ updateScriptTags = (activeDocument, newScripts, callback) ->
   )
 
 extractTrackedAssets = (doc) ->
-  return [].slice.call(doc.querySelectorAll('[data-turbolinks-track]'))
+  [].slice.call(doc.querySelectorAll('[data-turbolinks-track]'))
 
 filterForNodeType = (nodeType) ->
   (node) -> node.nodeName == nodeType

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -64,7 +64,7 @@ describe 'Turbolinks', ->
 
   visit = ({options, url}, callback) ->
     $(document).one('page:load', (event) ->
-      setTimeout((-> callback(event)), 0)
+      setTimeout((-> callback(event) if callback), 0)
     )
     Turbolinks.visit('/' + url, options)
 
@@ -184,6 +184,33 @@ describe 'Turbolinks', ->
         visit url: 'singleLinkInHead', ->
           assertLinks(['foo.css'])
           done()
+
+    it 'many subsequent navigations do not break head asset tracking', (done) ->
+      requestsToDo = 10
+
+      recursiveVisit = ->
+        visit url: 'twoLinksInHead', ->
+          visit url: 'singleLinkInHead', ->
+            assertLinks(['foo.css'])
+            requestsToDo -=1
+            return recursiveVisit() if requestsToDo > 0
+            done()
+
+      recursiveVisit()
+
+      it 'many subsequent synchronous navigations do not break head asset tracking', (done) ->
+        requestsToDo = 10
+
+        recursiveVisit = ->
+          visit url: 'twoLinksInHead'
+          visit url: 'singleLinkInHead'
+          visit url: 'twoLinksInHead', ->
+              assertLinks(['foo.css', 'bar.css'])
+              requestsToDo -=1
+              return recursiveVisit() if requestsToDo > 0
+              done()
+
+        recursiveVisit()
 
     describe 'transforms the current head to have the same links in the same order as the upstream document with minimal moves', ->
       it 'maintains order when moving from an empty head to a page with link nodes.', (done) ->

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -185,33 +185,6 @@ describe 'Turbolinks', ->
           assertLinks(['foo.css'])
           done()
 
-    it 'many subsequent navigations do not break head asset tracking', (done) ->
-      requestsToDo = 10
-
-      recursiveVisit = ->
-        visit url: 'twoLinksInHead', ->
-          visit url: 'singleLinkInHead', ->
-            assertLinks(['foo.css'])
-            requestsToDo -=1
-            return recursiveVisit() if requestsToDo > 0
-            done()
-
-      recursiveVisit()
-
-      it 'many subsequent synchronous navigations do not break head asset tracking', (done) ->
-        requestsToDo = 10
-
-        recursiveVisit = ->
-          visit url: 'twoLinksInHead'
-          visit url: 'singleLinkInHead'
-          visit url: 'twoLinksInHead', ->
-              assertLinks(['foo.css', 'bar.css'])
-              requestsToDo -=1
-              return recursiveVisit() if requestsToDo > 0
-              done()
-
-        recursiveVisit()
-
     describe 'transforms the current head to have the same links in the same order as the upstream document with minimal moves', ->
       it 'maintains order when moving from an empty head to a page with link nodes.', (done) ->
         linkTagInserted = sinon.spy()


### PR DESCRIPTION
This PR fixes the `sometimes the app breaks` case where a user navigates several times within a TG application using `0.3.0`.

The breakages were the result of `Turbohead#update` missing the upstream document's css when processing it. This only occurred randomly (somewhere between 1/10 and 1/20 times) and only on safari. It seems to be the result of:

```
extractTrackedAssets = (doc) ->
  for node in doc.head.children when node.dataset.turbolinksTrack?
    node
```

Where the result of extractTrackedAssets would be different than the new implementation:

```
extractTrackedAssets = (doc) ->
  return [].slice.call(doc.querySelectorAll('[data-turbolinks-track]'))
```

However, only sometimes, and only on safari. Debugging through or adding `console.log` to the loop steps would make the function perform as expected.

Since `querySelector` does not give you a live collection, it seems to be some strange browser level behaviour involving live collections of DOM elements. Similar flakiness was also addressed previously in  https://github.com/Shopify/turbograft/pull/93.

~~In addition, there was some concern that we were not testing large numbers of subsequent navigations (though this is not specifically the issue as far as I can tell), so I've included additional tests for this case.~~