### PR TITLE
Fix partial replace head tracking

### DIFF
--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -132,15 +132,16 @@ class window.Turbolinks
     options.updatePushState ?= true
     if upstreamDocument = processResponse(xhr)
       reflectNewUrl url if options.updatePushState
-      unless options.partialReplace
-        return new TurboHead(document, upstreamDocument).update(
+      if options.partialReplace
+        updateBody(upstreamDocument, xhr, options)
+      else
+        new TurboHead(document, upstreamDocument).update(
           onHeadUpdateSuccess = ->
             updateBody(upstreamDocument, xhr, options)
           ,
           onHeadUpdateError = ->
             Turbolinks.fullPageNavigate(url.absolute)
         )
-      return updateBody(upstreamDocument, xhr, options)
     else
       triggerEvent 'page:error', xhr
       Turbolinks.fullPageNavigate(url.absolute) if url?

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -130,28 +130,32 @@ class window.Turbolinks
   @loadPage: (url, xhr, options = {}) ->
     triggerEvent 'page:receive'
     options.updatePushState ?= true
-    if upstreamDocument = processResponse(xhr, options.partialReplace)
+    if upstreamDocument = processResponse(xhr)
       reflectNewUrl url if options.updatePushState
-
-      new TurboHead(document, upstreamDocument).update(
-        onHeadUpdateSuccess = ->
-          nodes = changePage(
-            upstreamDocument.querySelector('title')?.textContent,
-            removeNoscriptTags(upstreamDocument.querySelector('body')),
-            CSRFToken.get(upstreamDocument).token,
-            'runScripts',
-            options
-          )
-          reflectRedirectedUrl(xhr) if options.updatePushState
-          options.onLoadFunction?()
-          triggerEvent 'page:load', nodes
-        ,
-        onHeadUpdateError = ->
-          Turbolinks.fullPageNavigate(url.absolute)
-      )
+      unless options.partialReplace
+        return new TurboHead(document, upstreamDocument).update(
+          onHeadUpdateSuccess = ->
+            updateBody(upstreamDocument, xhr, options)
+          ,
+          onHeadUpdateError = ->
+            Turbolinks.fullPageNavigate(url.absolute)
+        )
+      return updateBody(upstreamDocument, xhr, options)
     else
       triggerEvent 'page:error', xhr
       Turbolinks.fullPageNavigate(url.absolute) if url?
+
+  updateBody = (upstreamDocument, xhr, options) ->
+    nodes = changePage(
+      upstreamDocument.querySelector('title')?.textContent,
+      removeNoscriptTags(upstreamDocument.querySelector('body')),
+      CSRFToken.get(upstreamDocument).token,
+      'runScripts',
+      options
+    )
+    reflectRedirectedUrl(xhr) if options.updatePushState
+    options.onLoadFunction?()
+    triggerEvent 'page:load', nodes
 
   changePage = (title, body, csrfToken, runScripts, options = {}) ->
     document.title = title if title

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -327,7 +327,7 @@ class window.Turbolinks
   pageChangePrevented = (url) ->
     !triggerEvent('page:before-change', url)
 
-  processResponse = (xhr, partial = false) ->
+  processResponse = (xhr) ->
     clientOrServerError = ->
       return false if xhr.status == 422 # we want to render form validations
       400 <= xhr.status < 600

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -363,6 +363,18 @@ describe 'Turbolinks', ->
   describe 'with partial page replacement', ->
     beforeEach -> window.globalStub = stub()
 
+    it 'head assets are not inserted during partial replace', (done) ->
+      visit url: 'singleScriptInHead', options: {partialReplace: true, onlyKeys: ['turbo-area']}, ->
+        assertScripts([])
+        done()
+
+    it 'head assets are not removed during partial replace', (done) ->
+      visit url: 'singleLinkInHead', ->
+        assertLinks(['foo.css'])
+        visit url: 'twoLinksInHead', options: {partialReplace: true, onlyKeys: ['turbo-area']}, ->
+          assertLinks(['foo.css'])
+          done()
+
     it 'script tags are evaluated when they are the subject of a partial replace', (done) ->
       visit url: 'inlineScriptInBody', options: {partialReplace: true, onlyKeys: ['turbo-area']}, ->
         assert(globalStub.calledOnce, 'Script tag was not evaluated :(')


### PR DESCRIPTION
This PR fixes partial replaces inadvertently triggering head asset updates. This was usually not causing issues, but in some cases could break stuff.

I should note that this was partially to blame for the spike in `url.absolute` errors. Submitting a remote form would call: 

```
        Page.refresh
          response: xhr
          onlyKeys: @refreshOnSuccess
```

`Page.refresh` would then trigger

```
    options.partialReplace = true
    options.onLoadFunction = callback

    xhr = options.response
    delete options.response
    Turbolinks.loadPage null, xhr, options
```

Which would then try to update the head assets, with an error callback that looked like:

```
onHeadUpdateError = ->
          Turbolinks.fullPageNavigate(url.absolute)
```

Where `url` is null. 

Preventing head asset updates on partial request should fix the new instances of this error that all occurred with a `tg-remote` related last event.

The old instances of this error are a bit more insidious and will be addressed in an upcoming PR.
