### PR TITLE
fix null url exceptions 

### DIFF
--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -150,7 +150,8 @@ class window.Turbolinks
           Turbolinks.fullPageNavigate(url.absolute)
       )
     else
-      Turbolinks.fullPageNavigate(url.absolute)
+      triggerEvent 'page:error', xhr
+      Turbolinks.fullPageNavigate(url.absolute) if url?
 
   changePage = (title, body, csrfToken, runScripts, options = {}) ->
     document.title = title if title


### PR DESCRIPTION
**What**
This PR fixes null url exceptions by preventing full page navigation on null and introduces `page:error` for cases where `processResponse` fails.

**Why Tho?**
Currently we have quite a lot of `null is not an object` errors from [this line](https://github.com/Shopify/turbograft/blob/master/lib/assets/javascripts/turbograft/turbolinks.coffee#L153) on production where `remote`'s returning an error are causing `turbolinks.loadPage` to be called with `url: null` through `Page.refresh` (bear with me here). 

Passing `newUrl` [here](https://github.com/Shopify/turbograft/blob/master/lib/assets/javascripts/turbograft/page.coffee#L25) would solve the problem by allowing the page to be refreshed when such an error occurs. 

However, we don't actually want to do that, because the user's page state would be disrupted by this refresh. As such, after discussing with @qq99 and @GoodForOneFare we are going with this simple null checking solution. This allows the consumer of the library to decide how an error should be handled by hooking into `page:error` and avoids both the random exception and full page refreshes cleanly.