### PR TITLE
Revert to the simpler solution, :(

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ In botany, one can take parts of a tree and splice it onto another tree.  The DO
 
 ## One render path
 Turbograft gives you the ability to maintain a single, canonical render path for views. Your ERB views are the single definition of what will be rendered, without the worry of conditionally fetching snippets of HTML from elsewhere. This approach leads to clear, simplified code.
+
 ## Client-side performance
 Partial page refreshes mean that CSS and JavaScript are only reloaded when you need them to be. Turbograft improves on the native, single-page application feel for the user while keeping these benefits inherited from Turbolinks.
+
+Head asset tracking means that you can split your large CSS and Javascript bundles into smaller area bundles, decreasing your page weight and further increasing the responsiveness of your app.
+
 ## Simplicity
 Turbograft was built with simplicity in mind. It intends to offer the smallest amount of overhead required on top of a traditional Rails stack to solve the problem of making a Rails app feel native to the browser.
 
@@ -159,6 +163,16 @@ and
 - no ancestor of the input has the `data-tg-remote-noserialize` attribute
 
 The `data-tg-remote-noserialize` is useful in scenarios where a whole section of the page should be editable, i.e. not `disabled`, but should only conditionally be submitted to the server.
+
+## Head Asset Tracking
+### NOTE: This functionality is experimental, has changed significantly since 0.3.0, and may change again in the future before 1.0
+The Turbohead module allows you to track css and javascript assets in the head of the document and change them intelligently. This can be useful in large applications which want to lighten their asset weight by splitting their script and style bundles by area.
+
+When a `<script>` or `<link>` tag with a unique name in it's `data-turbolinks-track` is encountered in a response document Turbograft will insert it into the active DOM and, if it's a script, force it to execute.
+
+If an asset with a different `src`/`href` but the same `data-turbolinks-track` value is found upstream, turbograft will force a full page refresh. This prevents potential multiple executions of a script bundle when a new version of your app is shipped.
+
+As of version `0.4.0`, this functionality has been made backwards compatible. If `data-turbolinks-track="true"` head assets are present, turbograft will cause a full page refresh when the set is changed in any way.
 
 ## Example App
 

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -176,7 +176,7 @@ reorderActiveLinks = (activeLinks, upstreamLinks) ->
               document.head.insertBefore(linkClone, currentLink.nextSibling)
               removeLink(linkToMove, startIndex)
               activeLinksCopy.splice(i, 0, linkToMove)
-              triggerEvent('page:after-link-inserted', linkToMove)
+              triggerEvent('page:after-link-inserted', linkClone)
               return
           else
             addNewReorder(linkToMove, currentLink, pendingReorders)

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -60,18 +60,6 @@ asyncSeries = (tasks, callback) ->
   task = tasks.shift()
   task(-> asyncSeries(tasks, callback))
 
-
-asyncParallel = (tasks, callback) ->
-  tasksRemaining = tasks.length
-  return callback() if tasksRemaining == 0
-
-  done = () ->
-    tasksRemaining--
-    if (tasksRemaining == 0)
-      callback()
-
-  tasks.forEach((task) -> task(done))
-
 insertScriptTask = (activeDocument, scriptNode) ->
   # We need to clone script tags in order to ensure that the browser executes them.
   newNode = activeDocument.createElement('SCRIPT')

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -31,7 +31,7 @@ filterForNodeType = (nodeType) ->
 
 noMatchFor = ({attribute, inCollection}) ->
   (node) ->
-    !inCollection.some((nodeFromCollection) -> node[attribute] != nodeFromCollection[attribute])
+    !inCollection.some((nodeFromCollection) -> node[attribute] == nodeFromCollection[attribute])
 
 hasAssetConflicts = (activeAssets) ->
   (newNode) ->
@@ -42,10 +42,10 @@ hasAssetConflicts = (activeAssets) ->
     )
 
 updateLinkTags = (activeDocument, newLinks, callback) ->
-  asyncParallel(
-    newLinks.map((linkNode) -> insertLinkTask(activeDocument, linkNode)),
-    callback
-  )
+  # style tag load events don't work in all browsers
+  # as such we just hope they load ¯\_(ツ)_/¯
+  newLinks.forEach((linkNode) -> insertLinkTask(activeDocument, linkNode)())
+  callback()
 
 updateScriptTags = (activeDocument, newScripts, callback) ->
   asyncSeries(

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -4,26 +4,24 @@ class window.TurboHead
   update: (successCallback, failureCallback) ->
     activeAssets = extractTrackedAssets(@activeDocument)
     upstreamAssets = extractTrackedAssets(@upstreamDocument)
-    {activeScripts, newScripts} = processScripts(activeAssets, upstreamAssets)
 
-    if hasScriptConflict(activeScripts, newScripts)
+    newScripts = upstreamAssets
+      .filter(filterForNodeType('SCRIPT'))
+      .filter(noMatchFor({attribute: 'src', inCollection: activeAssets}))
+
+    newLinks = upstreamAssets
+      .filter(filterForNodeType('LINK'))
+      .filter(noMatchFor({attribute: 'href', inCollection: activeAssets}))
+
+    if newScripts.concat(newLinks).some(hasAssetConflicts(activeAssets))
       return failureCallback()
 
-    updateLinkTags(activeAssets, upstreamAssets)
-    updateScriptTags(@activeDocument, newScripts, successCallback)
+    updateTasks = [
+      (done) => updateLinkTags(@activeDocument, newLinks, done),
+      (done) => updateScriptTags(@activeDocument, newScripts, done)
+    ]
 
-updateLinkTags = (activeAssets, upstreamAssets) ->
-  activeLinks = activeAssets.filter(filterForNodeType('LINK'))
-  upstreamLinks = upstreamAssets.filter(filterForNodeType('LINK'))
-  remainingActiveLinks = removeStaleLinks(activeLinks, upstreamLinks)
-  reorderedActiveLinks = reorderActiveLinks(remainingActiveLinks, upstreamLinks)
-  insertNewLinks(reorderedActiveLinks, upstreamLinks)
-
-updateScriptTags = (activeDocument, newScripts, callback) ->
-  asyncSeries(
-    newScripts.map((scriptNode) -> insertScriptTask(activeDocument, scriptNode)),
-    callback
-  )
+    asyncSeries(updateTasks, successCallback)
 
 extractTrackedAssets = (doc) ->
   [].slice.call(doc.querySelectorAll('[data-turbolinks-track]'))
@@ -31,179 +29,65 @@ extractTrackedAssets = (doc) ->
 filterForNodeType = (nodeType) ->
   (node) -> node.nodeName == nodeType
 
-hasScriptConflict = (activeScripts, newScripts) ->
-  hasExistingScriptAssetName = (upstreamNode) ->
-    activeScripts.some (activeNode) ->
-      upstreamNode.dataset.turbolinksTrackScriptAs == activeNode.dataset.turbolinksTrackScriptAs
+noMatchFor = ({attribute, inCollection}) ->
+  (node) ->
+    !inCollection.some((nodeFromCollection) -> node[attribute] != nodeFromCollection[attribute])
 
-  newScripts.some(hasExistingScriptAssetName)
+hasAssetConflicts = (activeAssets) ->
+  (newNode) ->
+    activeAssets.some((activeNode) ->
+      trackName = newNode.dataset.turbolinksTrack
+      trackName == activeNode.dataset.turbolinksTrack &&
+      trackName != 'true'
+    )
+
+updateLinkTags = (activeDocument, newLinks, callback) ->
+  asyncParallel(
+    newLinks.map((linkNode) -> insertLinkTask(activeDocument, linkNode)),
+    callback
+  )
+
+updateScriptTags = (activeDocument, newScripts, callback) ->
+  asyncSeries(
+    newScripts.map((scriptNode) -> insertScriptTask(activeDocument, scriptNode)),
+    callback
+  )
 
 asyncSeries = (tasks, callback) ->
   return callback() if tasks.length == 0
   task = tasks.shift()
   task(-> asyncSeries(tasks, callback))
 
+
+asyncParallel = (tasks, callback) ->
+  tasksRemaining = tasks.length
+  return callback() if tasksRemaining == 0
+
+  done = () ->
+    tasksRemaining--
+    if (tasksRemaining == 0)
+      callback()
+
+  tasks.forEach((task) -> task(done))
+
 insertScriptTask = (activeDocument, scriptNode) ->
   # We need to clone script tags in order to ensure that the browser executes them.
   newNode = activeDocument.createElement('SCRIPT')
   newNode.setAttribute(attr.name, attr.value) for attr in scriptNode.attributes
   newNode.appendChild(activeDocument.createTextNode(scriptNode.innerHTML))
+  insertAssetTask(activeDocument, newNode, 'script')
 
-  return (done) ->
-    onScriptEvent = (event) ->
-      triggerEvent('page:script-error', event) if event.type == 'error'
-      newNode.removeEventListener('load', onScriptEvent)
-      newNode.removeEventListener('error', onScriptEvent)
+insertLinkTask = (activeDocument, node) ->
+  insertAssetTask(activeDocument, node.cloneNode(), 'link')
+
+insertAssetTask = (activeDocument, newNode, name) ->
+  (done) ->
+    onAssetEvent = (event) ->
+      triggerEvent("page:#{name}-error", event) if event.type == 'error'
+      newNode.removeEventListener('load', onAssetEvent)
+      newNode.removeEventListener('error', onAssetEvent)
       done()
-    newNode.addEventListener('load', onScriptEvent)
-    newNode.addEventListener('error', onScriptEvent)
+    newNode.addEventListener('load', onAssetEvent)
+    newNode.addEventListener('error', onAssetEvent)
     activeDocument.head.appendChild(newNode)
-    triggerEvent('page:after-script-inserted', newNode)
-
-processScripts = (activeAssets, upstreamAssets) ->
-  activeScripts = activeAssets.filter(filterForNodeType('SCRIPT'))
-  upstreamScripts = upstreamAssets.filter(filterForNodeType('SCRIPT'))
-  hasNewSrc = (upstreamNode) ->
-    activeScripts.every (activeNode) ->
-      upstreamNode.src != activeNode.src
-
-  newScripts = upstreamScripts.filter(hasNewSrc)
-
-  {activeScripts, newScripts}
-
-removeStaleLinks = (activeLinks, upstreamLinks) ->
-  isStaleLink = (link) ->
-    upstreamLinks.every (upstreamLink) ->
-      upstreamLink.href != link.href
-
-  staleLinks = activeLinks.filter(isStaleLink)
-
-  for staleLink in staleLinks
-    removedLink = document.head.removeChild(staleLink)
-    triggerEvent('page:after-link-removed', removedLink)
-
-  activeLinks.filter((link) -> !isStaleLink(link))
-
-reorderAlreadyExists = (link1, link2, reorders) ->
-  reorders.some (reorderPair) ->
-    link1 in reorderPair && link2 in reorderPair
-
-generateReorderGraph = (activeLinks, upstreamLinks) ->
-  reorders = []
-  for activeLink1 in activeLinks
-    for activeLink2 in activeLinks
-      continue if activeLink1.href == activeLink2.href
-      continue if reorderAlreadyExists(activeLink1, activeLink2, reorders)
-
-      upstreamLink1 = upstreamLinks.filter((link) -> link.href == activeLink1.href)[0]
-      upstreamLink2 = upstreamLinks.filter((link) -> link.href == activeLink2.href)[0]
-
-      orderHasChanged =
-        (activeLinks.indexOf(activeLink1) < activeLinks.indexOf(activeLink2)) !=
-        (upstreamLinks.indexOf(upstreamLink1) < upstreamLinks.indexOf(upstreamLink2))
-
-      reorders.push([activeLink1, activeLink2]) if orderHasChanged
-  reorders
-
-nextMove = (activeLinks, reorders) ->
-  changesAssociatedTo = (link) ->
-    reorders.filter (reorderPair) ->
-      link in reorderPair
-
-  linksSortedByMovePriority = activeLinks
-    .slice()
-    .sort (link1, link2) ->
-      changesAssociatedTo(link2).length - changesAssociatedTo(link1).length
-
-  linkToMove = linksSortedByMovePriority[0]
-
-  linksToPassBy = changesAssociatedTo(linkToMove).map (reorderPair) ->
-    (reorderPair.filter (link) -> link.href != linkToMove.href)[0]
-
-  {linkToMove, linksToPassBy}
-
-reorderActiveLinks = (activeLinks, upstreamLinks) ->
-  activeLinksCopy = activeLinks.slice()
-  pendingReorders = generateReorderGraph(activeLinksCopy, upstreamLinks)
-
-  removeReorder = (link1, link2) ->
-    reorderToRemove = (pendingReorders.filter (reorderPair) ->
-      link1 in reorderPair && link2 in reorderPair)[0]
-    indexToRemove = pendingReorders.indexOf(reorderToRemove)
-    pendingReorders.splice(indexToRemove, 1)
-
-  addNewReorder = (link1, link2) ->
-    pendingReorders.push [link1, link2]
-
-  markReorderAsFinished = (linkToMove, linkToPass, remainingLinksToPass) ->
-    removeReorder(linkToMove, linkToPass)
-    removalIndex = remainingLinksToPass.indexOf(linkToPass)
-    remainingLinksToPass.splice(removalIndex, 1)
-
-  removeLink = (linkToRemove, indexOfLink) ->
-    removedLink = document.head.removeChild(linkToRemove)
-    triggerEvent('page:after-link-removed', removedLink)
-    activeLinksCopy.splice(indexOfLink, 1)
-
-  performMove = (linkToMove, linksToPassBy) ->
-    moveDirection = if activeLinksCopy.indexOf(linkToMove) > activeLinksCopy.indexOf(linksToPassBy[0]) then 'UP' else 'DOWN'
-    startIndex = activeLinksCopy.indexOf(linkToMove)
-
-    switch moveDirection
-      when 'UP'
-        for i in [(startIndex - 1)..0]
-          currentLink = activeLinksCopy[i]
-          if currentLink in linksToPassBy
-            markReorderAsFinished(linkToMove, currentLink, linksToPassBy)
-
-            if linksToPassBy.length == 0
-              linkClone = linkToMove.cloneNode()
-              document.head.insertBefore(linkClone, currentLink)
-              removeLink(linkToMove, startIndex)
-              activeLinksCopy.splice(i, 0, linkClone)
-              triggerEvent('page:after-link-inserted', linkClone)
-              return
-          else
-            addNewReorder(linkToMove, currentLink, pendingReorders)
-      when 'DOWN'
-        for i in [(startIndex + 1)...activeLinksCopy.length]
-          currentLink = activeLinksCopy[i]
-          if currentLink in linksToPassBy
-            markReorderAsFinished(linkToMove, currentLink, linksToPassBy)
-
-            if linksToPassBy.length == 0
-              linkClone = linkToMove.cloneNode()
-              document.head.insertBefore(linkClone, currentLink.nextSibling)
-              removeLink(linkToMove, startIndex)
-              activeLinksCopy.splice(i, 0, linkToMove)
-              triggerEvent('page:after-link-inserted', linkClone)
-              return
-          else
-            addNewReorder(linkToMove, currentLink, pendingReorders)
-
-  while pendingReorders.length > 0
-    {linkToMove, linksToPassBy} = nextMove(activeLinksCopy, pendingReorders)
-    performMove(linkToMove, linksToPassBy)
-
-  activeLinksCopy
-
-insertNewLinks = (activeLinks, upstreamLinks) ->
-  isNewLink = (link) ->
-    activeLinks.every (activeLink) ->
-      activeLink.href != link.href
-
-  upstreamLinks
-    .filter(isNewLink)
-    .reverse() # This is because we can't insert before a sibling that hasn't been inserted yet.
-    .forEach (newUpstreamLink) ->
-      index = upstreamLinks.indexOf(newUpstreamLink)
-      newActiveLink = newUpstreamLink.cloneNode()
-      if index == upstreamLinks.length - 1
-        document.head.appendChild(newActiveLink)
-        activeLinks.push(newActiveLink)
-      else
-        targetIndex = activeLinks.indexOf((activeLinks.filter (link) ->
-          link.href == upstreamLinks[index + 1].href)[0])
-        document.head.insertBefore(newActiveLink, activeLinks[targetIndex])
-        activeLinks.splice(targetIndex, 0, newActiveLink)
-      triggerEvent('page:after-link-inserted', newActiveLink)
+    triggerEvent("page:after-#{name}-inserted", newNode)

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -1,23 +1,23 @@
 class window.TurboHead
   constructor: (@activeDocument, @upstreamDocument) ->
-
-  update: (successCallback, failureCallback) ->
-    activeAssets = extractTrackedAssets(@activeDocument)
-    upstreamAssets = extractTrackedAssets(@upstreamDocument)
-
-    newScripts = upstreamAssets
+    @activeAssets = extractTrackedAssets(@activeDocument)
+    @upstreamAssets = extractTrackedAssets(@upstreamDocument)
+    @newScripts = @upstreamAssets
       .filter(filterForNodeType('SCRIPT'))
-      .filter(noMatchFor({attribute: 'src', inCollection: activeAssets}))
+      .filter(noMatchFor({attribute: 'src', inCollection: @activeAssets}))
 
-    newLinks = upstreamAssets
+    @newLinks = @upstreamAssets
       .filter(filterForNodeType('LINK'))
-      .filter(noMatchFor({attribute: 'href', inCollection: activeAssets}))
+      .filter(noMatchFor({attribute: 'href', inCollection: @activeAssets}))
 
-    if newScripts.concat(newLinks).some(hasAssetConflicts(activeAssets))
-      return failureCallback()
+  hasAssetConflicts: () ->
+    @newScripts
+      .concat(@newLinks)
+      .some(hasAssetConflicts(@activeAssets))
 
-    updateLinkTags(@activeDocument, newLinks)
-    updateScriptTags(@activeDocument, newScripts, successCallback)
+  insertNewAssets: (callback) ->
+    updateLinkTags(@activeDocument, @newLinks)
+    updateScriptTags(@activeDocument, @newScripts, callback)
 
 extractTrackedAssets = (doc) ->
   [].slice.call(doc.querySelectorAll('[data-turbolinks-track]'))

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -23,8 +23,11 @@ class window.TurboHead
     if anonymousActiveAssets.length != anonymousUpstreamAssets.length
       return true
 
-    anonymousActiveAssets.some(
-      noAttributeMatchesIn(TRACKED_ATTRIBUTE_NAME, anonymousUpstreamAssets)
+    noMatchingSrc = noAttributeMatchesIn('src', anonymousUpstreamAssets)
+    noMatchingHref = noAttributeMatchesIn('href', anonymousUpstreamAssets)
+
+    anonymousActiveAssets.some((node) ->
+      noMatchingSrc(node) || noMatchingHref(node)
     )
 
   hasNamedAssetConflicts: () ->

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -157,11 +157,11 @@ reorderActiveLinks = (activeLinks, upstreamLinks) ->
             markReorderAsFinished(linkToMove, currentLink, linksToPassBy)
 
             if linksToPassBy.length == 0
+              linkClone = linkToMove.cloneNode()
+              document.head.insertBefore(linkClone, currentLink)
               removeLink(linkToMove, startIndex)
-
-              document.head.insertBefore(linkToMove, activeLinksCopy[i])
-              activeLinksCopy.splice(i, 0, linkToMove)
-              triggerEvent('page:after-link-inserted', linkToMove)
+              activeLinksCopy.splice(i, 0, linkClone)
+              triggerEvent('page:after-link-inserted', linkClone)
               return
           else
             addNewReorder(linkToMove, currentLink, pendingReorders)
@@ -172,15 +172,10 @@ reorderActiveLinks = (activeLinks, upstreamLinks) ->
             markReorderAsFinished(linkToMove, currentLink, linksToPassBy)
 
             if linksToPassBy.length == 0
+              linkClone = linkToMove.cloneNode()
+              document.head.insertBefore(linkClone, currentLink.nextSibling)
               removeLink(linkToMove, startIndex)
-
-              targetIndex = i - 1
-              if targetIndex == activeLinksCopy.length - 1
-                document.head.appendChild(linkToMove)
-                activeLinksCopy.push(linkToMove)
-              else
-                document.head.insertBefore(linkToMove, activeLinksCopy[targetIndex + 1])
-                activeLinksCopy.splice(targetIndex + 1, 0, linkToMove)
+              activeLinksCopy.splice(i, 0, linkToMove)
               triggerEvent('page:after-link-inserted', linkToMove)
               return
           else

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -44,7 +44,7 @@ hasAssetConflicts = (activeAssets) ->
 updateLinkTags = (activeDocument, newLinks, callback) ->
   # style tag load events don't work in all browsers
   # as such we just hope they load ¯\_(ツ)_/¯
-  newLinks.forEach((linkNode) -> insertLinkTask(activeDocument, linkNode)())
+  newLinks.forEach((linkNode) -> insertLinkTask(activeDocument, linkNode)(noOp))
   callback()
 
 updateScriptTags = (activeDocument, newScripts, callback) ->
@@ -52,6 +52,8 @@ updateScriptTags = (activeDocument, newScripts, callback) ->
     newScripts.map((scriptNode) -> insertScriptTask(activeDocument, scriptNode)),
     callback
   )
+
+noOp = -> null
 
 asyncSeries = (tasks, callback) ->
   return callback() if tasks.length == 0

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -16,12 +16,8 @@ class window.TurboHead
     if newScripts.concat(newLinks).some(hasAssetConflicts(activeAssets))
       return failureCallback()
 
-    updateTasks = [
-      (done) => updateLinkTags(@activeDocument, newLinks, done),
-      (done) => updateScriptTags(@activeDocument, newScripts, done)
-    ]
-
-    asyncSeries(updateTasks, successCallback)
+    updateLinkTags(@activeDocument, newLinks)
+    updateScriptTags(@activeDocument, newScripts, successCallback)
 
 extractTrackedAssets = (doc) ->
   [].slice.call(doc.querySelectorAll('[data-turbolinks-track]'))
@@ -41,11 +37,10 @@ hasAssetConflicts = (activeAssets) ->
       trackName != 'true'
     )
 
-updateLinkTags = (activeDocument, newLinks, callback) ->
+updateLinkTags = (activeDocument, newLinks) ->
   # style tag load events don't work in all browsers
   # as such we just hope they load ¯\_(ツ)_/¯
-  newLinks.forEach((linkNode) -> insertLinkTask(activeDocument, linkNode)(noOp))
-  callback()
+  newLinks.forEach((linkNode) -> insertLinkTask(activeDocument, linkNode)())
 
 updateScriptTags = (activeDocument, newScripts, callback) ->
   asyncSeries(
@@ -76,7 +71,7 @@ insertAssetTask = (activeDocument, newNode, name) ->
       triggerEvent("page:#{name}-error", event) if event.type == 'error'
       newNode.removeEventListener('load', onAssetEvent)
       newNode.removeEventListener('error', onAssetEvent)
-      done()
+      done() if typeof done == 'function'
     newNode.addEventListener('load', onAssetEvent)
     newNode.addEventListener('error', onAssetEvent)
     activeDocument.head.appendChild(newNode)

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -135,13 +135,9 @@ class window.Turbolinks
       if options.partialReplace
         updateBody(upstreamDocument, xhr, options)
       else
-        new TurboHead(document, upstreamDocument).update(
-          onHeadUpdateSuccess = ->
-            updateBody(upstreamDocument, xhr, options)
-          ,
-          onHeadUpdateError = ->
-            Turbolinks.fullPageNavigate(url.absolute)
-        )
+        turbohead = new TurboHead(document, upstreamDocument)
+        return Turbolinks.fullPageNavigate(url.absolute) if turbohead.hasAssetConflicts()
+        turbohead.insertNewAssets(-> updateBody(upstreamDocument, xhr, options))
     else
       triggerEvent 'page:error', xhr
       Turbolinks.fullPageNavigate(url.absolute) if url?

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -131,12 +131,15 @@ class window.Turbolinks
     triggerEvent 'page:receive'
     options.updatePushState ?= true
     if upstreamDocument = processResponse(xhr)
-      reflectNewUrl url if options.updatePushState
       if options.partialReplace
+        reflectNewUrl url if options.updatePushState
         updateBody(upstreamDocument, xhr, options)
       else
         turbohead = new TurboHead(document, upstreamDocument)
-        return Turbolinks.fullPageNavigate(url.absolute) if turbohead.hasAssetConflicts()
+        if turbohead.hasAssetConflicts()
+          return Turbolinks.fullPageNavigate(url.absolute)
+
+        reflectNewUrl url if options.updatePushState
         turbohead.insertNewAssets(-> updateBody(upstreamDocument, xhr, options))
     else
       triggerEvent 'page:error', xhr

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -131,15 +131,13 @@ class window.Turbolinks
     triggerEvent 'page:receive'
     options.updatePushState ?= true
     if upstreamDocument = processResponse(xhr)
+      reflectNewUrl url if options.updatePushState
       if options.partialReplace
-        reflectNewUrl url if options.updatePushState
         updateBody(upstreamDocument, xhr, options)
       else
         turbohead = new TurboHead(document, upstreamDocument)
         if turbohead.hasAssetConflicts()
           return Turbolinks.fullPageNavigate(url.absolute)
-
-        reflectNewUrl url if options.updatePushState
         turbohead.insertNewAssets(-> updateBody(upstreamDocument, xhr, options))
     else
       triggerEvent 'page:error', xhr

--- a/test/javascripts/fixtures/js/routes.coffee
+++ b/test/javascripts/fixtures/js/routes.coffee
@@ -98,7 +98,7 @@ window.ROUTES = {
     """
   ],
 
-  twoScriptsInHeadTrackTrueAgain: [
+  twoScriptsInHeadTrackTrueOneChanged: [
     200,
     {'Content-Type':'text/html'},
     """
@@ -108,7 +108,7 @@ window.ROUTES = {
           <script src='#{ASSET_FIXTURES['foo.js']}'
             data-turbolinks-track="true"
             type="text/javascript"></script>
-          <script src='#{ASSET_FIXTURES['bar.js']}'
+          <script src='#{ASSET_FIXTURES['c.js']}'
             data-turbolinks-track="true"
             type="text/javascript"></script>
           <title>Hi there!</title>
@@ -378,6 +378,42 @@ window.ROUTES = {
         <head>
           <link href='#{ASSET_FIXTURES['foo.css']}' data-turbolinks-track="foo"></link>
           <link href='#{ASSET_FIXTURES['bar.css']}' data-turbolinks-track="bar"></link>
+          <title>Hi there!</title>
+        </head>
+        <body>
+          <div id="turbo-area" refresh="turbo-area"></div>
+        </body>
+      </html>
+    """
+  ],
+
+  twoLinksInHeadTrackTrue: [
+    200,
+    {'Content-Type':'text/html'},
+    """
+      <!doctype html>
+      <html>
+        <head>
+          <link href='#{ASSET_FIXTURES['foo.css']}' data-turbolinks-track="true"></link>
+          <link href='#{ASSET_FIXTURES['bar.css']}' data-turbolinks-track="true"></link>
+          <title>Hi there!</title>
+        </head>
+        <body>
+          <div id="turbo-area" refresh="turbo-area"></div>
+        </body>
+      </html>
+    """
+  ],
+
+  twoLinksInHeadTrackTrueOneChanged: [
+    200,
+    {'Content-Type':'text/html'},
+    """
+      <!doctype html>
+      <html>
+        <head>
+          <link href='#{ASSET_FIXTURES['a.css']}' data-turbolinks-track="true"></link>
+          <link href='#{ASSET_FIXTURES['bar.css']}' data-turbolinks-track="true"></link>
           <title>Hi there!</title>
         </head>
         <body>

--- a/test/javascripts/fixtures/js/routes.coffee
+++ b/test/javascripts/fixtures/js/routes.coffee
@@ -24,8 +24,7 @@ window.ROUTES = {
       <html>
         <head>
           <script src='#{ASSET_FIXTURES['foo.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="foo"
+            data-turbolinks-track="foo"
             type="text/javascript"></script>
           <title>Hi there!</title>
         </head>
@@ -44,12 +43,10 @@ window.ROUTES = {
       <html>
         <head>
           <script src='#{ASSET_FIXTURES['foo.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="foo"
+            data-turbolinks-track="foo"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['bar.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="bar"
+            data-turbolinks-track="bar"
             type="text/javascript"></script>
           <title>Hi there!</title>
         </head>
@@ -70,12 +67,10 @@ window.ROUTES = {
           <script
             src=""
             id="broken-script"
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="broken"
+            data-turbolinks-track="broken"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['foo.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="foo"
+            data-turbolinks-track="foo"
             type="text/javascript"></script>
           <title>Hi there!</title>
         </head>
@@ -96,8 +91,7 @@ window.ROUTES = {
       <html>
         <head>
           <script src='#{ASSET_FIXTURES['bar.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="bar"
+            data-turbolinks-track="bar"
             type="text/javascript"></script>
           <title>Hi there!</title>
         </head>
@@ -116,8 +110,7 @@ window.ROUTES = {
       <html>
         <head>
           <script src='#{ASSET_FIXTURES['bar.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="foo"
+            data-turbolinks-track="foo"
             type="text/javascript"></script>
           <title>Hi there!</title>
         </head>
@@ -136,8 +129,7 @@ window.ROUTES = {
       <html>
         <head>
           <script src='#{ASSET_FIXTURES['b.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="b"
+            data-turbolinks-track="b"
             type="text/javascript"></script>
         </head>
         <body>
@@ -155,16 +147,13 @@ window.ROUTES = {
       <html>
         <head>
           <script src='#{ASSET_FIXTURES['a.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="a"
+            data-turbolinks-track="a"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['b.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="b"
+            data-turbolinks-track="b"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['c.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="c"
+            data-turbolinks-track="c"
             type="text/javascript"></script>
           <title>Hi there!</title>
         </head>
@@ -183,16 +172,13 @@ window.ROUTES = {
       <html>
         <head>
           <script src='#{ASSET_FIXTURES['a.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="a"
+            data-turbolinks-track="a"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['c.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="c"
+            data-turbolinks-track="c"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['b.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="b"
+            data-turbolinks-track="b"
             type="text/javascript"></script>
           <title>Hi there!</title>
         </head>
@@ -211,16 +197,13 @@ window.ROUTES = {
       <html>
         <head>
           <script src='#{ASSET_FIXTURES['b.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="b"
+            data-turbolinks-track="b"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['a.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="a"
+            data-turbolinks-track="a"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['c.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="c"
+            data-turbolinks-track="c"
             type="text/javascript"></script>
           <title>Hi there!</title>
         </head>
@@ -239,16 +222,13 @@ window.ROUTES = {
       <html>
         <head>
           <script src='#{ASSET_FIXTURES['b.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="b"
+            data-turbolinks-track="b"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['c.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="c"
+            data-turbolinks-track="c"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['a.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="a"
+            data-turbolinks-track="a"
             type="text/javascript"></script>
           <title>Hi there!</title>
         </head>
@@ -267,16 +247,13 @@ window.ROUTES = {
       <html>
         <head>
           <script src='#{ASSET_FIXTURES['c.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="c"
+            data-turbolinks-track="c"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['a.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="a"
+            data-turbolinks-track="a"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['b.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="b"
+            data-turbolinks-track="b"
             type="text/javascript"></script>
           <title>Hi there!</title>
         </head>
@@ -295,16 +272,13 @@ window.ROUTES = {
       <html>
         <head>
           <script src='#{ASSET_FIXTURES['c.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="c"
+            data-turbolinks-track="c"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['b.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="b"
+            data-turbolinks-track="b"
             type="text/javascript"></script>
           <script src='#{ASSET_FIXTURES['a.js']}'
-            data-turbolinks-track="true"
-            data-turbolinks-track-script-as="a"
+            data-turbolinks-track="a"
             type="text/javascript"></script>
           <title>Hi there!</title>
         </head>

--- a/test/javascripts/fixtures/js/routes.coffee
+++ b/test/javascripts/fixtures/js/routes.coffee
@@ -35,6 +35,25 @@ window.ROUTES = {
     """
   ],
 
+  singleScriptInHeadTrackTrue: [
+    200,
+    {'Content-Type':'text/html'},
+    """
+      <!doctype html>
+      <html>
+        <head>
+          <script src='#{ASSET_FIXTURES['foo.js']}'
+            data-turbolinks-track="true"
+            type="text/javascript"></script>
+          <title>Hi there!</title>
+        </head>
+        <body>
+          <div id="turbo-area" refresh="turbo-area"></div>
+        </body>
+      </html>
+    """
+  ],
+
   twoScriptsInHead: [
     200,
     {'Content-Type':'text/html'},
@@ -52,6 +71,50 @@ window.ROUTES = {
         </head>
         <body>
           <div id="turbo-area" refresh="turbo-area"></div>
+        </body>
+      </html>
+    """
+  ],
+
+  twoScriptsInHeadTrackTrue: [
+    200,
+    {'Content-Type':'text/html'},
+    """
+      <!doctype html>
+      <html>
+        <head>
+          <script src='#{ASSET_FIXTURES['foo.js']}'
+            data-turbolinks-track="true"
+            type="text/javascript"></script>
+          <script src='#{ASSET_FIXTURES['bar.js']}'
+            data-turbolinks-track="true"
+            type="text/javascript"></script>
+          <title>Hi there!</title>
+        </head>
+        <body>
+          <div id="turbo-area" refresh="turbo-area"></div>
+        </body>
+      </html>
+    """
+  ],
+
+  twoScriptsInHeadTrackTrueAgain: [
+    200,
+    {'Content-Type':'text/html'},
+    """
+      <!doctype html>
+      <html>
+        <head>
+          <script src='#{ASSET_FIXTURES['foo.js']}'
+            data-turbolinks-track="true"
+            type="text/javascript"></script>
+          <script src='#{ASSET_FIXTURES['bar.js']}'
+            data-turbolinks-track="true"
+            type="text/javascript"></script>
+          <title>Hi there!</title>
+        </head>
+        <body>
+          <div id="turbo-area" refresh="turbo-area">Merp</div>
         </body>
       </html>
     """
@@ -296,7 +359,7 @@ window.ROUTES = {
       <!doctype html>
       <html>
         <head>
-          <link href='#{ASSET_FIXTURES['foo.css']}' data-turbolinks-track="true"></link>
+          <link href='#{ASSET_FIXTURES['foo.css']}' data-turbolinks-track="foo"></link>
           <title>Hi there!</title>
         </head>
         <body>
@@ -313,8 +376,8 @@ window.ROUTES = {
       <!doctype html>
       <html>
         <head>
-          <link href='#{ASSET_FIXTURES['foo.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['bar.css']}' data-turbolinks-track="true"></link>
+          <link href='#{ASSET_FIXTURES['foo.css']}' data-turbolinks-track="foo"></link>
+          <link href='#{ASSET_FIXTURES['bar.css']}' data-turbolinks-track="bar"></link>
           <title>Hi there!</title>
         </head>
         <body>
@@ -331,128 +394,8 @@ window.ROUTES = {
       <!doctype html>
       <html>
         <head>
-          <link href='#{ASSET_FIXTURES['bar.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['foo.css']}' data-turbolinks-track="true"></link>
-          <title>Hi there!</title>
-        </head>
-        <body>
-          <div id="turbo-area" refresh="turbo-area"></div>
-        </body>
-      </html>
-    """
-  ],
-
-  fourLinksInHeadABCD: [
-    200,
-    {'Content-Type':'text/html'},
-    """
-      <!doctype html>
-      <html>
-        <head>
-          <link href='#{ASSET_FIXTURES['a.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['b.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['c.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['d.css']}' data-turbolinks-track="true"></link>
-          <title>Hi there!</title>
-        </head>
-        <body>
-          <div id="turbo-area" refresh="turbo-area"></div>
-        </body>
-      </html>
-    """
-  ],
-
-  fourLinksInHeadBCDA: [
-    200,
-    {'Content-Type':'text/html'},
-    """
-      <!doctype html>
-      <html>
-        <head>
-          <link href='#{ASSET_FIXTURES['b.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['c.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['d.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['a.css']}' data-turbolinks-track="true"></link>
-          <title>Hi there!</title>
-        </head>
-        <body>
-          <div id="turbo-area" refresh="turbo-area"></div>
-        </body>
-      </html>
-    """
-  ],
-
-  fourLinksInHeadCDAB: [
-    200,
-    {'Content-Type':'text/html'},
-    """
-      <!doctype html>
-      <html>
-        <head>
-          <link href='#{ASSET_FIXTURES['c.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['d.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['a.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['b.css']}' data-turbolinks-track="true"></link>
-          <title>Hi there!</title>
-        </head>
-        <body>
-          <div id="turbo-area" refresh="turbo-area"></div>
-        </body>
-      </html>
-    """
-  ],
-
-  fourLinksInHeadCDBA: [
-    200,
-    {'Content-Type':'text/html'},
-    """
-      <!doctype html>
-      <html>
-        <head>
-          <link href='#{ASSET_FIXTURES['c.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['d.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['b.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['a.css']}' data-turbolinks-track="true"></link>
-          <title>Hi there!</title>
-        </head>
-        <body>
-          <div id="turbo-area" refresh="turbo-area"></div>
-        </body>
-      </html>
-    """
-  ],
-
-  fourLinksInHeadCBDA: [
-    200,
-    {'Content-Type':'text/html'},
-    """
-      <!doctype html>
-      <html>
-        <head>
-          <link href='#{ASSET_FIXTURES['c.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['b.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['d.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['a.css']}' data-turbolinks-track="true"></link>
-          <title>Hi there!</title>
-        </head>
-        <body>
-          <div id="turbo-area" refresh="turbo-area"></div>
-        </body>
-      </html>
-    """
-  ],
-
-  fourLinksInHeadDCBA: [
-    200,
-    {'Content-Type':'text/html'},
-    """
-      <!doctype html>
-      <html>
-        <head>
-          <link href='#{ASSET_FIXTURES['d.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['c.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['b.css']}' data-turbolinks-track="true"></link>
-          <link href='#{ASSET_FIXTURES['a.css']}' data-turbolinks-track="true"></link>
+          <link href='#{ASSET_FIXTURES['bar.css']}' data-turbolinks-track="bar"></link>
+          <link href='#{ASSET_FIXTURES['foo.css']}' data-turbolinks-track="foo"></link>
           <title>Hi there!</title>
         </head>
         <body>

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -134,15 +134,6 @@ describe 'Turbolinks', ->
           assert.equal(linkTagInserted.callCount, 1)
           done()
 
-    it 'dispatches page:after-link-removed event when removing a link on navigation', (done) ->
-      linkTagRemoved = sinon.spy()
-      $(document).on 'page:after-link-removed', linkTagRemoved
-
-      visit url: 'singleLinkInHead', ->
-        visit url: 'noScriptsOrLinkInHead', ->
-          assert.equal(linkTagRemoved.callCount, 1)
-          done()
-
     it 'inserts link with a new href into empty head on navigation', (done) ->
       visit url: 'noScriptsOrLinkInHead', ->
         assertLinks([])
@@ -157,96 +148,12 @@ describe 'Turbolinks', ->
           assertLinks(['foo.css', 'bar.css'])
           done()
 
-    it 'inserts link with a new href before exiting scripts in head on navigation', (done) ->
-      visit url: 'singleLinkInHead', ->
-        assertLinks(['foo.css'])
-        visit url: 'twoLinksInHeadReverseOrder', ->
-          assertLinks(['bar.css', 'foo.css'])
-          done()
-
     it 'does not reinsert link with existing href into identical head on navigation', (done) ->
       visit url: 'singleLinkInHead', ->
         assertLinks(['foo.css'])
         visit url: 'singleLinkInHead', ->
           assertLinks(['foo.css'])
           done()
-
-    it 'removes link when navigating to a page with an empty head', (done) ->
-      visit url: 'singleLinkInHead', ->
-        assertLinks(['foo.css'])
-        visit url: 'noScriptsOrLinkInHead', ->
-          assertLinks([])
-          done()
-
-    it 'removes link when navigating to a page with the href missing', (done) ->
-      visit url: 'twoLinksInHead', ->
-        assertLinks(['foo.css', 'bar.css'])
-        visit url: 'singleLinkInHead', ->
-          assertLinks(['foo.css'])
-          done()
-
-    describe 'transforms the current head to have the same links in the same order as the upstream document with minimal moves', ->
-      it 'maintains order when moving from an empty head to a page with link nodes.', (done) ->
-        linkTagInserted = sinon.spy()
-        $(document).on 'page:after-link-inserted', linkTagInserted
-        visit url: 'fourLinksInHeadABCD', ->
-          assertLinks(['a.css', 'b.css', 'c.css', 'd.css'])
-          assert.equal(linkTagInserted.callCount, 4)
-          done()
-
-      it 'performs the minimal number of moves for an upwards transform ABCD to BCDA.', (done) ->
-        visit url: 'fourLinksInHeadABCD', ->
-          linkTagInserted = sinon.spy()
-          $(document).on 'page:after-link-inserted', linkTagInserted
-          visit url: 'fourLinksInHeadBCDA', ->
-            assertLinks(['b.css', 'c.css', 'd.css', 'a.css'])
-            assert.equal(linkTagInserted.callCount, 1) # Move A
-            done()
-
-      it 'performs the minimal number of moves for a downwards transform BCDA to ABCD.', (done) ->
-        visit url: 'fourLinksInHeadBCDA', ->
-          linkTagInserted = sinon.spy()
-          $(document).on 'page:after-link-inserted', linkTagInserted
-          visit url: 'fourLinksInHeadABCD', ->
-            assertLinks(['a.css', 'b.css', 'c.css', 'd.css'])
-            assert.equal(linkTagInserted.callCount, 1) # Move A
-            done()
-
-      it 'maintains order when moving from a head with links ABCD to links CDAB.', (done) ->
-        visit url: 'fourLinksInHeadABCD', ->
-          linkTagInserted = sinon.spy()
-          $(document).on 'page:after-link-inserted', linkTagInserted
-          visit url: 'fourLinksInHeadCDAB', ->
-            assertLinks(['c.css', 'd.css', 'a.css', 'b.css'])
-            assert.equal(linkTagInserted.callCount, 2) # Move A,B or C,D
-            done()
-
-      it 'maintains order when moving from a head with links ABCD to links CDBA.', (done) ->
-        visit url: 'fourLinksInHeadABCD', ->
-          linkTagInserted = sinon.spy()
-          $(document).on 'page:after-link-inserted', linkTagInserted
-          visit url: 'fourLinksInHeadCDBA', ->
-            assertLinks(['c.css', 'd.css', 'b.css', 'a.css'])
-            assert.equal(linkTagInserted.callCount, 2) # Move A,B
-            done()
-
-      it 'maintains order when moving from a head with links ABCD to links CBDA.', (done) ->
-        visit url: 'fourLinksInHeadABCD', ->
-          linkTagInserted = sinon.spy()
-          $(document).on 'page:after-link-inserted', linkTagInserted
-          visit url: 'fourLinksInHeadCBDA', ->
-            assertLinks(['c.css', 'b.css', 'd.css', 'a.css'])
-            assert.equal(linkTagInserted.callCount, 2) # Move A,B or A,C
-            done()
-
-      it 'maintains order when moving from a head with links ABCD to links DCBA.', (done) ->
-        visit url: 'fourLinksInHeadABCD', ->
-          linkTagInserted = sinon.spy()
-          $(document).on 'page:after-link-inserted', linkTagInserted
-          visit url: 'fourLinksInHeadDCBA', ->
-            assertLinks(['d.css', 'c.css', 'b.css', 'a.css'])
-            assert.equal(linkTagInserted.callCount, 3) # Move any 3
-            done()
 
   describe 'head script tag tracking', ->
     it 'dispatches page:after-script-inserted event when inserting a script on navigation', (done) ->
@@ -348,7 +255,7 @@ describe 'Turbolinks', ->
           assertScripts(['foo.js', 'bar.js'])
           done()
 
-    it 'refreshes page when a data-turbolinks-track-script-as src changes', (done) ->
+    it 'refreshes page when a data-turbolinks-track value matches but src changes', (done) ->
       visit url: 'singleScriptInHead', ->
         visit url: 'singleScriptInHeadWithDifferentSourceButSameName', ->
           assert(Turbolinks.fullPageNavigate.called, 'Should perform a full page refresh.')

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -138,9 +138,7 @@ describe 'Turbolinks', ->
     describe 'using data-turbolinks-track="true"', ->
       startFromFixture = (route) ->
         fixtureHTML = ROUTES[route][2]
-        $fixture = $(fixtureHTML)
-        document.body.innerHTML = $fixture.find('body').html()
-        document.head.innerHTML = $fixture.find('head').html()
+        document.documentElement.innerHTML = fixtureHTML
 
       it 'refreshes page when a new tracked node is present', (done) ->
         visit url: 'singleScriptInHeadTrackTrue', ->
@@ -150,13 +148,25 @@ describe 'Turbolinks', ->
       it 'refreshes page when an extant tracked node is missing', (done) ->
         startFromFixture('twoScriptsInHeadTrackTrue')
         visit url: 'singleScriptInHeadTrackTrue', ->
-          assert(Turbolinks.fullPageNavigate.callCount, 2, 'Should perform two full page refreshes.')
+          assert(Turbolinks.fullPageNavigate.called, 'Should perform a full page refresh.')
+          done()
+
+      it 'refreshes page when upstream and active tracked scripts lengths are equal but one\'s source changes', (done) ->
+        startFromFixture('twoScriptsInHeadTrackTrue')
+        visit url: 'twoScriptsInHeadTrackTrueOneChanged', ->
+          assert(Turbolinks.fullPageNavigate.called, 'Should perform a full page refresh.')
+          done()
+
+      it 'refreshes page when upstream and active tracked links lengths are equal but one\'s source changes', (done) ->
+        startFromFixture('twoLinksInHeadTrackTrue')
+        visit url: 'twoLinksInHeadTrackTrueOneChanged', ->
+          assert(Turbolinks.fullPageNavigate.called, 'Should perform a full page refresh.')
           done()
 
       it 'does not refresh page when tracked nodes have matching sources', (done) ->
         startFromFixture('singleScriptInHeadTrackTrue')
         visit url: 'singleScriptInHeadTrackTrue', ->
-          assert.equal(Turbolinks.fullPageNavigate.callCount, 1, 'Should not perform a full page refresh.')
+          assert(Turbolinks.fullPageNavigate.notCalled, 'Should not perform a full page refresh.')
           done()
 
     describe 'link tags', ->


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/4889856/18115448/6afe2f76-6f0d-11e6-8a97-44a23c6a8783.png)
![image](https://cloud.githubusercontent.com/assets/4889856/18115463/85d7959e-6f0d-11e6-84c2-17cd34e5d596.png)

I'm very sad tonight.

The graph was causing flickering on new asset bundles no matter how I refactored it due to stylesheet parsing. Load events on link tags weren't working in test environments or some of the browsers I tried. The only solutions seemed to be extremely verbose and hacky (such as setting a polling function to see if asset definitions were loaded by reaching into style tags, or using other nonsense like that)

As such, I just pulled a big old 🔥  and went with the simplest possible solution that gets us what we need.

On the brightside, I kept things at a nice balance of modular and simple, so it should be relatively easy to enhance our solution if/when we think up better ones. If we can work around test environments and are ok with older browsers (like literally firefox from a couple months ago) exploding, we could have a more robust solution again in a very small PR.

TLDR:
- We only ever insert new head assets
- `data-turbolinks-track-as` and `data-turbolinks-track` are now merged, using `data-turbolinks-track='foo'` is the same as using both of the old attributes together with a `track-as` of foo.
- We don't even care about load events from links. Don't worry bout it.
- Our solution suits our needs better than stealing mainstream Turbolink's because we don't want a full page refresh when we navigate to a page with less `link` tags unless we specify.

Anyway, I'm going to bed now, talk to y'all tommorrow :p
