### PR TITLE
Refactor Process Doc, Add new Error

### DIFF
--- a/lib/assets/javascripts/turbograft/document.coffee
+++ b/lib/assets/javascripts/turbograft/document.coffee
@@ -1,0 +1,11 @@
+TurboGraft.Document =
+  create: (html) ->
+    if /<(html|body)/i.test(html)
+      doc = document.documentElement.cloneNode()
+      doc.innerHTML = html
+    else
+      doc = document.documentElement.cloneNode(true)
+      doc.querySelector('body').innerHTML = html
+    doc.head = doc.querySelector('head')
+    doc.body = doc.querySelector('body')
+    doc

--- a/lib/assets/javascripts/turbograft/response.coffee
+++ b/lib/assets/javascripts/turbograft/response.coffee
@@ -1,0 +1,23 @@
+class TurboGraft.Response
+  constructor: (@xhr) ->
+
+  valid: -> @hasRenderableHttpStatus() && @hasValidContent()
+
+  document: ->
+    if @valid()
+      TurboGraft.Document.create(@xhr.responseText)
+
+  hasRenderableHttpStatus: ->
+    return true if @xhr.status == 422 # we want to render form validations
+    !(400 <= @xhr.status < 600)
+
+  hasValidContent: ->
+    if contentType = @xhr.getResponseHeader('Content-Type')
+      contentType.match(/^(?:text\/html|application\/xhtml\+xml|application\/xml)(?:;|$)/)
+    else
+      throw new Error("Error encountered for XHR Response: #{this}")
+
+  toString: () ->
+    "URL: #{@xhr.responseURL}, " +
+    "ReadyState: #{@xhr.readyState}, " +
+    "Headers: #{@xhr.getAllResponseHeaders()}"

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -10,7 +10,7 @@ waitForCompleteDownloads = ->
     scriptPromises[url]
   Promise.all(loadingPromises)
 
-class window.TurboHead
+class TurboGraft.TurboHead
   constructor: (@activeDocument, @upstreamDocument) ->
     @activeAssets = extractTrackedAssets(@activeDocument)
     @upstreamAssets = extractTrackedAssets(@upstreamDocument)

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -130,12 +130,12 @@ class window.Turbolinks
   @loadPage: (url, xhr, options = {}) ->
     triggerEvent 'page:receive'
     options.updatePushState ?= true
-    if upstreamDocument = processResponse(xhr)
+    if upstreamDocument = new TurboGraft.Response(xhr).document()
       if options.partialReplace
         reflectNewUrl url if options.updatePushState
         updateBody(upstreamDocument, xhr, options)
       else
-        turbohead = new TurboHead(document, upstreamDocument)
+        turbohead = new TurboGraft.TurboHead(document, upstreamDocument)
         if turbohead.hasAssetConflicts()
           return Turbolinks.fullPageNavigate(url.absolute)
         reflectNewUrl url if options.updatePushState
@@ -329,18 +329,6 @@ class window.Turbolinks
   pageChangePrevented = (url) ->
     !triggerEvent('page:before-change', url)
 
-  processResponse = (xhr) ->
-    clientOrServerError = ->
-      return false if xhr.status == 422 # we want to render form validations
-      400 <= xhr.status < 600
-
-    validContent = ->
-      xhr.getResponseHeader('Content-Type').match /^(?:text\/html|application\/xhtml\+xml|application\/xml)(?:;|$)/
-
-    if !clientOrServerError() && validContent()
-      upstreamDocument = createDocument(xhr.responseText)
-      return upstreamDocument
-
   installHistoryChangeHandler = (event) ->
     if event.state?.turbolinks
       Turbolinks.visit event.target.location.href
@@ -349,17 +337,6 @@ class window.Turbolinks
   # some browsers fire on the initial page load.
   bypassOnLoadPopstate = (fn) ->
     setTimeout fn, 500
-
-  createDocument = (html) ->
-    if /<(html|body)/i.test(html)
-      doc = document.documentElement.cloneNode()
-      doc.innerHTML = html
-    else
-      doc = document.documentElement.cloneNode(true)
-      doc.querySelector('body').innerHTML = html
-    doc.head = doc.querySelector('head')
-    doc.body = doc.querySelector('body')
-    doc
 
   if browserSupportsTurbolinks
     @visit = fetch

--- a/test/example/app/assets/config/manifest.js
+++ b/test/example/app/assets/config/manifest.js
@@ -1,0 +1,15 @@
+//link application.js
+//link component_url_test.js
+//link csrf_token_test.js
+//link initializers_test.js
+//link jquery.js
+//link jquery_ujs.js
+//link link_test.js
+//link page_test.js
+//link remote_test.js
+//link test_helper.js
+//link turbolinks_test.js
+//link_tree support
+//link_tree turbograft
+//link_tree fixtures
+//link_tree fixtures/js

--- a/test/example/config/initializers/assets.rb
+++ b/test/example/config/initializers/assets.rb
@@ -3,11 +3,13 @@ Example::Application.config.assets.precompile += %w(
   application.self.js
   component_url_test.self.js
   csrf_token_test.self.js
+  document_test.self.js
   initializers_test.self.js
   jquery.self.js
   jquery_ujs.self.js
   link_test.self.js
   page_test.self.js
+  response_test.self.js
   remote_test.self.js
   support/sinon.self.js
   support/chai.self.js
@@ -25,6 +27,8 @@ Example::Application.config.assets.precompile += %w(
   turbograft/remote.self.js
   turbograft/turbolinks.self.js
   turbograft/turbohead.self.js
+  turbograft/document.self.js
+  turbograft/response.self.js
   turbolinks_test.self.js
   turbohead_test.self.js
   fixtures/css/foo.css

--- a/test/javascripts/document_test.coffee
+++ b/test/javascripts/document_test.coffee
@@ -1,0 +1,27 @@
+describe 'TurboGraft.Document', ->
+  it 'is defined', ->
+    assert(TurboGraft.Document)
+
+  describe '@create', ->
+    it 'returns a document with the given html when given a full html document', ->
+      headHTML = '<link src="merp">'
+      bodyHTML = '<div>merp merp</div>'
+      template = "<html><head>#{headHTML}</head><body>#{bodyHTML}</body></html>"
+
+      doc = TurboGraft.Document.create(template)
+      assert.equal(doc.body.innerHTML, bodyHTML)
+      assert.equal(doc.head.innerHTML, headHTML)
+
+    it 'returns a document with the given body when given only a body tag', ->
+      bodyHTML = '<div>merp merp</div>'
+      template = "<body>#{bodyHTML}</body>"
+
+      doc = TurboGraft.Document.create(template)
+      assert.equal(doc.body.innerHTML, bodyHTML)
+
+
+    it 'returns a document with the given html at the root of the body when given a snippet', ->
+      template = '<div>merp merp</div>'
+
+      doc = TurboGraft.Document.create(template)
+      assert.equal(doc.body.innerHTML, template)

--- a/test/javascripts/fixtures/js/routes.coffee
+++ b/test/javascripts/fixtures/js/routes.coffee
@@ -1,4 +1,22 @@
 window.ROUTES = {
+  serverError: [
+    500,
+    {'Content-Type':'text/html'},
+    'error!'
+  ],
+
+  validationError: [
+    422,
+    {'Content-Type':'text/html'},
+    'error!'
+  ],
+
+  noContentType: [
+    500,
+    {},
+    'error!'
+  ],
+
   noScriptsOrLinkInHead: [
     200,
     {'Content-Type':'text/html'},

--- a/test/javascripts/response_test.coffee
+++ b/test/javascripts/response_test.coffee
@@ -1,0 +1,57 @@
+describe 'TurboGraft.Response', ->
+  sandbox = null
+
+  responseForFixture = (fixture, callback) ->
+    xhr = new XMLHttpRequest
+    xhr.open("GET", "/#{fixture}", true)
+    xhr.send()
+    xhr.onload = ->
+      callback(new TurboGraft.Response(xhr))
+    xhr.onerror = ->
+      callback(new TurboGraft.Response(xhr))
+
+  beforeEach ->
+    sandbox = sinon.sandbox.create()
+    sandbox.useFakeServer()
+    Object.keys(ROUTES).forEach (url) ->
+      sandbox.server.respondWith('/' + url, ROUTES[url])
+    sandbox.server.autoRespond = true
+
+  afterEach ->
+    sandbox.restore()
+
+  it 'is defined', ->
+    assert(TurboGraft.Response)
+
+  describe 'valid', ->
+    it 'returns false when a server error is encountered', (done) ->
+      responseForFixture 'serverError', (response) ->
+        assert(!response.valid(), 'response should not be valid when an error is received')
+        done()
+
+    it 'returns true when a 422 error is encountered', (done) ->
+      responseForFixture 'validationError', (response) ->
+        assert(response.valid(), 'response should be valid when a 422 error is received')
+        done()
+
+    it 'returns true when a success status is encountered', (done) ->
+      responseForFixture 'noScriptsOrLinkInHead', (response) ->
+        assert(response.valid(), 'response should be valid when a 200 is received')
+        done()
+
+    it 'throws an error when Content-Type is empty', (done) ->
+      responseForFixture 'noContentType', (response) ->
+        assert.throws(response.valid)
+        done()
+
+  describe 'document', ->
+    it 'returns TurboGraft.Document.create when valid', (done) ->
+      stub = sandbox.stub(TurboGraft.Document, 'create', -> 'document')
+      responseForFixture 'noScriptsOrLinkInHead', (response) ->
+        assert.equal(response.document(), 'document')
+        done()
+
+    it 'returns undefined when invalid', (done) ->
+      responseForFixture 'serverError', (response) ->
+        assert.equal(response.document(), undefined)
+        done()

--- a/test/javascripts/turbohead_test.coffee
+++ b/test/javascripts/turbohead_test.coffee
@@ -21,7 +21,7 @@ describe 'TurboHead', ->
   newRequest = (requestScripts) ->
     promiseQueue = promiseQueue.then ->
       new Promise (resolve) ->
-        head = new TurboHead(
+        head = new TurboGraft.TurboHead(
           activeDocument,
           fakeDocument(requestScripts)
         )
@@ -46,7 +46,7 @@ describe 'TurboHead', ->
     requests = []
 
   afterEach ->
-    TurboHead._testAPI.reset()
+    TurboGraft.TurboHead._testAPI.reset()
 
   describe 'script download queue', ->
     it 'downloads scripts in sequence', ->

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -86,7 +86,7 @@ describe 'Turbolinks', ->
     $("script").attr("data-turbolinks-eval", false)
     $("#mocha").attr("refresh-never", true)
 
-    TurboHead._testAPI.reset()
+    TurboGraft.TurboHead._testAPI.reset()
     resetPage()
 
   afterEach ->
@@ -396,8 +396,8 @@ describe 'Turbolinks', ->
 
     beforeEach ->
       promise = new Promise((resolve) -> resolver = resolve)
-      sandbox.stub(TurboHead.prototype, 'hasAssetConflicts').returns(false)
-      sandbox.stub(TurboHead.prototype, 'waitForAssets').returns(promise)
+      sandbox.stub(TurboGraft.TurboHead.prototype, 'hasAssetConflicts').returns(false)
+      sandbox.stub(TurboGraft.TurboHead.prototype, 'waitForAssets').returns(promise)
 
       xhr = new sinon.FakeXMLHttpRequest()
       xhr.open('POST', '/my/endpoint', true)


### PR DESCRIPTION
This PR accomplishes two primary goals:
- Address the occasional spikes of `Cannot read property 'match' of null` we've been getting for ages, and hopefully adds enough information to those cases that we can figure out why they're happening.
- Iteratively add some testing / refactor some code out of the main Turbolinks file.

@qq99 
@GoodForOneFare 