### PR TITLE
defend against nulls in full page navigate

### DIFF
--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -80,8 +80,11 @@ class window.Turbolinks
     fetchReplacement url, options
 
   @fullPageNavigate: (url) ->
-    triggerEvent('page:before-full-refresh', url: url)
-    document.location.href = url
+    if url?
+      url = (new ComponentUrl(url)).absolute
+      triggerEvent('page:before-full-refresh', url: url)
+      document.location.href = url
+    return
 
   @pushState: (state, title, url) ->
     window.history.pushState(state, title, url)
@@ -111,7 +114,7 @@ class window.Turbolinks
 
     xhr.onload = ->
       if xhr.status >= 500
-        Turbolinks.fullPageNavigate(url.absolute)
+        Turbolinks.fullPageNavigate(url)
       else
         Turbolinks.loadPage(url, xhr, options)
       xhr = null
@@ -121,7 +124,7 @@ class window.Turbolinks
       if xhr.statusText == "abort"
         xhr = null
         return
-      Turbolinks.fullPageNavigate(url.absolute)
+      Turbolinks.fullPageNavigate(url)
 
     xhr.send()
 
@@ -137,12 +140,12 @@ class window.Turbolinks
       else
         turbohead = new TurboHead(document, upstreamDocument)
         if turbohead.hasAssetConflicts()
-          return Turbolinks.fullPageNavigate(url.absolute)
+          return Turbolinks.fullPageNavigate(url)
         reflectNewUrl url if options.updatePushState
         turbohead.insertNewAssets(-> updateBody(upstreamDocument, xhr, options))
     else
       triggerEvent 'page:error', xhr
-      Turbolinks.fullPageNavigate(url.absolute) if url?
+      Turbolinks.fullPageNavigate(url)
 
   updateBody = (upstreamDocument, xhr, options) ->
     nodes = changePage(


### PR DESCRIPTION
This PR makes `Turbolinks.fullPageNavigate` deal with being given a null xhr by simply doing nothing.

~~I don't really want to merge this yet. It's a last resort to dealing with the `cannot read property 'absolute' of null` errors we've been seeing in production. I'd prefer that we figure out why we're sometimes getting null urls...~~

We're getting null urls when `remote` calls `Page.refresh` with`response: xhr`  and no url. This causes `Page` to call `Turbolinks.loadPage` directly with a `null` url.

![image](https://cloud.githubusercontent.com/assets/4889856/18390483/64ec41be-7678-11e6-86ac-f3fa88357653.png)

Now there are two forks where we end up in 😢 🏠 . If the response doesn't pass `processResponse` then we try to redirect. If it passes `processResponse` but has asset conflicts when `Turbohead` takes a look, we also try to redirect. In both of these cases we attempt to invoke `.absolute` on a `null`.

Oops, I lied. I actually already realized this after talking to @qq99 about it and stuck an `if url?` after one of the cases. What I neglected to realize is that we can still get an asset conflict here and hit the other `fullPageNavigate` call.

![image](https://cloud.githubusercontent.com/assets/4889856/18390620/efd66714-7678-11e6-9c6a-193b7e11337a.png)

I think we should probably have a more elegant solution to this than guarding for nulls. Maybe another method like `loadPage` that is specifically for the case where you have no url to pass?

We could always just stick a `ComponentUrl` call into `fullPageNavigate`, but  then we'd have refreshes when the asset bundle changes while a user is doing a form action. I wouldn't want to lose my 2000 word blog post because we rolled out some new css.

Anyway, this patch just no-ops `fullPageNavigate` when it's given a null url. ¯\_(ツ)_/¯

**TLDR**
When we change the asset bundle while someone is doing a remote it causes exceptions because we try to navigate to the `absolute` property of null. Enclosed is a trivial patch, but I think we should ~~refactor instead.~~ follow up with a refactor.

**For Your Consideration**
@qq99
@GoodForOneFare 
@Shopify/tnt 
