### PR TITLE
add test for null url to ComponentUrl tests for clarity of intention

### DIFF
--- a/test/javascripts/component_url_test.coffee
+++ b/test/javascripts/component_url_test.coffee
@@ -1,6 +1,6 @@
 describe 'ComponentUrl', ->
   describe 'constructor', ->
-    it 'uses current location when given not given a url', ->
+    it 'uses current location when not given a url', ->
       url = new ComponentUrl()
       assert.equal(url.absolute, location.href)
 

--- a/test/javascripts/component_url_test.coffee
+++ b/test/javascripts/component_url_test.coffee
@@ -1,5 +1,9 @@
 describe 'ComponentUrl', ->
   describe 'constructor', ->
+    it 'uses current location when given not given a url', ->
+      url = new ComponentUrl()
+      assert.equal(url.absolute, location.href)
+
     it 'does a noop and returns argument, if already a ComponentUrl', ->
       url = new ComponentUrl("http://example.com")
       url2 = new ComponentUrl(url)


### PR DESCRIPTION
This PR simply adds a test to `ComponentUrl` so that it's behaviour on a null url is clearer to consumers.

@Shopify/tnt 
@qq99 
@GoodForOneFare 