### PR TITLE
Fix concurrent requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Turbograft was built with simplicity in mind. It intends to offer the smallest a
 * Replace `//= require turbolinks` with `//= require turbograft` in _app/assets/javascripts/application.js_
 * Run `bundle install`
 
+## Dependencies
+
+Turbograft requires a browser that supports [`Promise`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise), or a polyfill (e.g., [core-js](https://github.com/zloirock/core-js).)
 
 ## Usage
 

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -3,7 +3,7 @@ TRACKED_ATTRIBUTE_NAME = 'turbolinksTrack'
 ANONYMOUS_TRACK_VALUE = 'true'
 
 scriptPromises = {}
-rejectPreviousRequest = null
+resolvePreviousRequest = null
 
 waitForCompleteDownloads = ->
   loadingPromises = Object.keys(scriptPromises).map (url) ->
@@ -24,7 +24,7 @@ class window.TurboHead
 
   @reset: ->
     scriptPromises = {}
-    rejectPreviousRequest = null
+    resolvePreviousRequest = null
 
   hasChangedAnonymousAssets: () ->
     anonymousUpstreamAssets = @upstreamAssets
@@ -52,10 +52,10 @@ class window.TurboHead
     @hasNamedAssetConflicts() || @hasChangedAnonymousAssets()
 
   waitForAssets: () ->
-    rejectPreviousRequest?()
+    resolvePreviousRequest?(isCanceled: true)
 
-    new Promise((resolve, reject) =>
-      rejectPreviousRequest = reject
+    new Promise((resolve) =>
+      resolvePreviousRequest = resolve
       waitForCompleteDownloads()
         .then(@_insertNewAssets)
         .then(waitForCompleteDownloads)

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -22,9 +22,11 @@ class window.TurboHead
       .filter(attributeMatches('nodeName', 'LINK'))
       .filter(noAttributeMatchesIn('href', @activeAssets))
 
-  @reset: ->
-    scriptPromises = {}
-    resolvePreviousRequest = null
+  @_testAPI: {
+    reset: ->
+      scriptPromises = {}
+      resolvePreviousRequest = null
+  }
 
   hasChangedAnonymousAssets: () ->
     anonymousUpstreamAssets = @upstreamAssets

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -139,10 +139,8 @@ class window.Turbolinks
         if turbohead.hasAssetConflicts()
           return Turbolinks.fullPageNavigate(url.absolute)
         reflectNewUrl url if options.updatePushState
-        turbohead.waitForAssets().then(->
-          updateBody(upstreamDocument, xhr, options)
-        ).catch(->
-          # A new request appeared during asset download.
+        turbohead.waitForAssets().then((result) ->
+          updateBody(upstreamDocument, xhr, options) unless result?.isCanceled
         )
     else
       triggerEvent 'page:error', xhr

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -139,7 +139,11 @@ class window.Turbolinks
         if turbohead.hasAssetConflicts()
           return Turbolinks.fullPageNavigate(url.absolute)
         reflectNewUrl url if options.updatePushState
-        turbohead.insertNewAssets(-> updateBody(upstreamDocument, xhr, options))
+        turbohead.waitForAssets().then(->
+          updateBody(upstreamDocument, xhr, options)
+        ).catch(->
+          # A new request appeared during asset download.
+        )
     else
       triggerEvent 'page:error', xhr
       Turbolinks.fullPageNavigate(url.absolute) if url?
@@ -303,6 +307,7 @@ class window.Turbolinks
       location = new ComponentUrl location
       preservedHash = if location.hasNoHash() then document.location.hash else ''
       Turbolinks.replaceState currentState, '', location.href + preservedHash
+
     return
 
   rememberReferer = ->

--- a/test/example/config/initializers/assets.rb
+++ b/test/example/config/initializers/assets.rb
@@ -1,4 +1,5 @@
 Example::Application.config.assets.precompile += %w(
+  vendor/promise-polyfill/promise.self.js
   application.self.js
   component_url_test.self.js
   csrf_token_test.self.js
@@ -11,6 +12,8 @@ Example::Application.config.assets.precompile += %w(
   support/sinon.self.js
   support/chai.self.js
   support/sinon-chai.self.js
+  fake_document.self.js
+  fake_script.self.js
   test_helper.self.js
   turbograft.self.js
   turbograft/click.self.js
@@ -23,6 +26,7 @@ Example::Application.config.assets.precompile += %w(
   turbograft/turbolinks.self.js
   turbograft/turbohead.self.js
   turbolinks_test.self.js
+  turbohead_test.self.js
   fixtures/css/foo.css
   fixtures/css/bar.css
   fixtures/css/order_testing/a.css

--- a/test/javascripts/fake_document.coffee
+++ b/test/javascripts/fake_document.coffee
@@ -1,0 +1,21 @@
+#= require ./fake_script
+
+window.fakeDocument = (scriptSources) ->
+  nodes = (fakeScript(src) for src in scriptSources)
+  newNodes = []
+
+  return {
+    createdScripts: newNodes
+    head: {
+      appendChild: () -> {}
+    }
+
+    createElement: () ->
+      script = fakeScript()
+      newNodes.push(script)
+      script
+
+    createTextNode: () -> {}
+
+    querySelectorAll: -> nodes
+  }

--- a/test/javascripts/fake_script.coffee
+++ b/test/javascripts/fake_script.coffee
@@ -1,0 +1,28 @@
+window.fakeScript = (src) ->
+  listeners = []
+  node = {
+    'data-turbolinks-track': src
+    attributes: [{name: 'src', value: src}]
+    isLoaded: false
+    src: src
+    nodeName: 'SCRIPT'
+
+    appendChild: () -> {}
+
+    setAttribute: (name, value) ->
+      if name == 'src'
+        @src = value
+      @attributes.push({name: name, value: value})
+
+    addEventListener: (eventName, listener) ->
+      return if eventName != 'load'
+      listeners.push(listener)
+
+    fireLoaded: () ->
+      listener({type: 'load'}) for listener in listeners
+      new Promise (resolve) ->
+        node.isLoaded = true
+        setTimeout -> resolve(node)
+
+    removeEventListener: () -> {}
+  }

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -94,10 +94,7 @@ describe 'Remote', ->
         fail: done
       , @initiating_target
 
-      simulateError = ->
-        listener(target: remote.xhr) for listener in remote.xhr.eventListeners.error
-
-      setTimeout(simulateError, 0)
+      remote.xhr.respond(404)
 
     it 'will call options.success() on success', (done) ->
       server = sinon.fakeServer.create()

--- a/test/javascripts/test_helper.js
+++ b/test/javascripts/test_helper.js
@@ -2,6 +2,7 @@
 //= require support/chai
 //= require support/sinon-chai
 //= require fixtures/js/routes
+//= require vendor/promise-polyfill/promise
 //= require application
 
 expect = chai.expect;
@@ -11,3 +12,5 @@ mock = sinon.mock;
 stub = sinon.stub;
 
 mocha.setup('tdd')
+sinon.assert.expose(chai.assert, {prefix: ''});
+chai.config.truncateThreshold = 9999;

--- a/test/javascripts/turbohead_test.coffee
+++ b/test/javascripts/turbohead_test.coffee
@@ -1,0 +1,118 @@
+#= require ./fake_document
+
+describe 'TurboHead', ->
+  activeDocument = null
+  promiseQueue = null
+  requests = []
+
+  assertScriptCount = (size, message) ->
+    promiseQueue = promiseQueue.then ->
+      assert.lengthOf(activeDocument.createdScripts, size, message)
+
+  finishScriptDownload = ->
+    promiseQueue = promiseQueue.then ->
+      new Promise (resolve) ->
+        unloaded = activeDocument.createdScripts.filter (script) ->
+          !script.isLoaded
+
+        unloaded[0].fireLoaded().then ->
+          setTimeout -> resolve(unloaded[0])
+
+  newRequest = (requestScripts) ->
+    promiseQueue = promiseQueue.then ->
+      new Promise (resolve) ->
+        head = new TurboHead(
+          activeDocument,
+          fakeDocument(requestScripts)
+        )
+
+        request = head.waitForAssets()
+        request.isFulfilled = false
+        request.isRejected = false
+        request
+          .then  -> request.isFulfilled = true
+          .catch -> request.isRejected = true
+        requests.push(request)
+
+        setTimeout(resolve, 50) # Wait for beginning of first script download.
+
+  beforeEach ->
+    activeDocument = fakeDocument([]) # Start with no scripts.
+    promiseQueue = Promise.resolve()
+    requests = []
+
+  afterEach ->
+    TurboHead.reset()
+
+  describe 'script download queue', ->
+    it 'downloads scripts in sequence', ->
+      newRequest(['a.js', 'b.js', 'c.js'])
+      assertScriptCount(1, 'first script download should be in progress')
+      finishScriptDownload()
+        .then (script) -> assert.equal(script.src, 'a.js')
+
+      assertScriptCount(2, 'first download complete should trigger second')
+      finishScriptDownload()
+        .then (script) -> assert.equal(script.src, 'b.js')
+
+      assertScriptCount(3, 'second download complete should trigger third')
+      finishScriptDownload()
+        .then (script) ->
+          assert.equal(script.src, 'c.js')
+          assert.isTrue(
+            requests[0].isFulfilled,
+            'all downloads complete should resolve request'
+          )
+
+    describe 'superceded requests', ->
+      it 'cancels stale requests', ->
+        newRequest(['d.js'])
+        newRequest([]).then ->
+          assert.isTrue(requests[0].isRejected)
+
+      it 'waits for previously queued scripts before starting new request', ->
+        newRequest(['a.js', 'b.js'])
+        newRequest([])
+        finishScriptDownload()
+        finishScriptDownload()
+        assertScriptCount(2, 'duplicate script elements should not be created')
+          .then ->
+            assert.isTrue(requests[0].isRejected)
+            assert.isTrue(requests[1].isFulfilled)
+
+      it 'does not add duplicate script tags for new requests', ->
+        newRequest(['a.js', 'b.js'])
+        newRequest(['a.js', 'b.js'])
+        assertScriptCount(1, 'first script should be downloading').then ->
+          assert.isFalse(requests[1].isFulfilled)
+        finishScriptDownload()
+        finishScriptDownload()
+          .then ->
+            assertScriptCount(2, 'duplicate script elements were created')
+            assert.isTrue(requests[1].isFulfilled)
+
+      it 'enqueues new scripts for new requests', ->
+        newRequest(['a.js', 'b.js'])
+        newRequest(['b.js', 'c.js', 'd.js'])
+        finishScriptDownload()
+        finishScriptDownload().then ->
+          assert.isFalse(requests[1].isFulfilled)
+        finishScriptDownload().then ->
+          assert.isFalse(requests[1].isFulfilled)
+        finishScriptDownload().then (script) ->
+          assertScriptCount(4, 'second request\'s assets should be downloaded')
+          assert.equal(
+            script.src, 'd.js',
+            'last queued script should be last downloaded'
+          )
+          assert.isTrue(requests[1].isFulfilled)
+
+      it 'does not reload completed scripts for new requests', ->
+        newRequest(['a.js', 'b.js'])
+        finishScriptDownload()
+        finishScriptDownload().then ->
+          assertScriptCount(2)
+          assert.isTrue(requests[0].isFulfilled)
+        newRequest(['a.js', 'b.js']).then ->
+          assertScriptCount(2)
+          assert.isTrue(requests[1].isFulfilled)

--- a/test/javascripts/turbohead_test.coffee
+++ b/test/javascripts/turbohead_test.coffee
@@ -46,7 +46,7 @@ describe 'TurboHead', ->
     requests = []
 
   afterEach ->
-    TurboHead.reset()
+    TurboHead._testAPI.reset()
 
   describe 'script download queue', ->
     it 'downloads scripts in sequence', ->

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -86,7 +86,7 @@ describe 'Turbolinks', ->
     $("script").attr("data-turbolinks-eval", false)
     $("#mocha").attr("refresh-never", true)
 
-    TurboHead.reset()
+    TurboHead._testAPI.reset()
     resetPage()
 
   afterEach ->

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -404,3 +404,27 @@ describe 'Turbolinks', ->
           assert.equal(1, nodes.length)
           assert.equal('div1', nodes[0].id)
           done()
+
+  describe 'asset loading finished', ->
+    SUCCESS_HTML_CONTENT = 'Hi there'
+    xhr = null
+    resolver = null
+
+    beforeEach ->
+      promise = new Promise((resolve) -> resolver = resolve)
+      sandbox.stub(TurboHead.prototype, 'hasAssetConflicts').returns(false)
+      sandbox.stub(TurboHead.prototype, 'waitForAssets').returns(promise)
+
+      xhr = new sinon.FakeXMLHttpRequest()
+      xhr.open('POST', '/my/endpoint', true)
+      xhr.respond(200, {'Content-Type':'text/html'}, SUCCESS_HTML_CONTENT)
+
+    it 'does not update document if the request was canceled', ->
+      resolver({isCanceled: true})
+      loadPromise = Turbolinks.loadPage('/foo', xhr)
+        .then -> assert.notInclude(document.body.innerHTML, SUCCESS_HTML_CONTENT)
+
+    it 'updates the document if the request was not canceled', ->
+      resolver()
+      loadPromise = Turbolinks.loadPage('/foo', xhr)
+        .then -> assert.include(document.body.innerHTML, SUCCESS_HTML_CONTENT)

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -86,6 +86,7 @@ describe 'Turbolinks', ->
     $("script").attr("data-turbolinks-eval", false)
     $("#mocha").attr("refresh-never", true)
 
+    TurboHead.reset()
     resetPage()
 
   afterEach ->

--- a/test/javascripts/vendor/promise-polyfill/promise.js
+++ b/test/javascripts/vendor/promise-polyfill/promise.js
@@ -1,0 +1,233 @@
+(function (root) {
+
+  // Store setTimeout reference so promise-polyfill will be unaffected by
+  // other code modifying setTimeout (like sinon.useFakeTimers())
+  var setTimeoutFunc = setTimeout;
+
+  function noop() {}
+  
+  // Polyfill for Function.prototype.bind
+  function bind(fn, thisArg) {
+    return function () {
+      fn.apply(thisArg, arguments);
+    };
+  }
+
+  function Promise(fn) {
+    if (typeof this !== 'object') throw new TypeError('Promises must be constructed via new');
+    if (typeof fn !== 'function') throw new TypeError('not a function');
+    this._state = 0;
+    this._handled = false;
+    this._value = undefined;
+    this._deferreds = [];
+
+    doResolve(fn, this);
+  }
+
+  function handle(self, deferred) {
+    while (self._state === 3) {
+      self = self._value;
+    }
+    if (self._state === 0) {
+      self._deferreds.push(deferred);
+      return;
+    }
+    self._handled = true;
+    Promise._immediateFn(function () {
+      var cb = self._state === 1 ? deferred.onFulfilled : deferred.onRejected;
+      if (cb === null) {
+        (self._state === 1 ? resolve : reject)(deferred.promise, self._value);
+        return;
+      }
+      var ret;
+      try {
+        ret = cb(self._value);
+      } catch (e) {
+        reject(deferred.promise, e);
+        return;
+      }
+      resolve(deferred.promise, ret);
+    });
+  }
+
+  function resolve(self, newValue) {
+    try {
+      // Promise Resolution Procedure: https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure
+      if (newValue === self) throw new TypeError('A promise cannot be resolved with itself.');
+      if (newValue && (typeof newValue === 'object' || typeof newValue === 'function')) {
+        var then = newValue.then;
+        if (newValue instanceof Promise) {
+          self._state = 3;
+          self._value = newValue;
+          finale(self);
+          return;
+        } else if (typeof then === 'function') {
+          doResolve(bind(then, newValue), self);
+          return;
+        }
+      }
+      self._state = 1;
+      self._value = newValue;
+      finale(self);
+    } catch (e) {
+      reject(self, e);
+    }
+  }
+
+  function reject(self, newValue) {
+    self._state = 2;
+    self._value = newValue;
+    finale(self);
+  }
+
+  function finale(self) {
+    if (self._state === 2 && self._deferreds.length === 0) {
+      Promise._immediateFn(function() {
+        if (!self._handled) {
+          Promise._unhandledRejectionFn(self._value);
+        }
+      });
+    }
+
+    for (var i = 0, len = self._deferreds.length; i < len; i++) {
+      handle(self, self._deferreds[i]);
+    }
+    self._deferreds = null;
+  }
+
+  function Handler(onFulfilled, onRejected, promise) {
+    this.onFulfilled = typeof onFulfilled === 'function' ? onFulfilled : null;
+    this.onRejected = typeof onRejected === 'function' ? onRejected : null;
+    this.promise = promise;
+  }
+
+  /**
+   * Take a potentially misbehaving resolver function and make sure
+   * onFulfilled and onRejected are only called once.
+   *
+   * Makes no guarantees about asynchrony.
+   */
+  function doResolve(fn, self) {
+    var done = false;
+    try {
+      fn(function (value) {
+        if (done) return;
+        done = true;
+        resolve(self, value);
+      }, function (reason) {
+        if (done) return;
+        done = true;
+        reject(self, reason);
+      });
+    } catch (ex) {
+      if (done) return;
+      done = true;
+      reject(self, ex);
+    }
+  }
+
+  Promise.prototype['catch'] = function (onRejected) {
+    return this.then(null, onRejected);
+  };
+
+  Promise.prototype.then = function (onFulfilled, onRejected) {
+    var prom = new (this.constructor)(noop);
+
+    handle(this, new Handler(onFulfilled, onRejected, prom));
+    return prom;
+  };
+
+  Promise.all = function (arr) {
+    var args = Array.prototype.slice.call(arr);
+
+    return new Promise(function (resolve, reject) {
+      if (args.length === 0) return resolve([]);
+      var remaining = args.length;
+
+      function res(i, val) {
+        try {
+          if (val && (typeof val === 'object' || typeof val === 'function')) {
+            var then = val.then;
+            if (typeof then === 'function') {
+              then.call(val, function (val) {
+                res(i, val);
+              }, reject);
+              return;
+            }
+          }
+          args[i] = val;
+          if (--remaining === 0) {
+            resolve(args);
+          }
+        } catch (ex) {
+          reject(ex);
+        }
+      }
+
+      for (var i = 0; i < args.length; i++) {
+        res(i, args[i]);
+      }
+    });
+  };
+
+  Promise.resolve = function (value) {
+    if (value && typeof value === 'object' && value.constructor === Promise) {
+      return value;
+    }
+
+    return new Promise(function (resolve) {
+      resolve(value);
+    });
+  };
+
+  Promise.reject = function (value) {
+    return new Promise(function (resolve, reject) {
+      reject(value);
+    });
+  };
+
+  Promise.race = function (values) {
+    return new Promise(function (resolve, reject) {
+      for (var i = 0, len = values.length; i < len; i++) {
+        values[i].then(resolve, reject);
+      }
+    });
+  };
+
+  // Use polyfill for setImmediate for performance gains
+  Promise._immediateFn = (typeof setImmediate === 'function' && function (fn) { setImmediate(fn); }) ||
+    function (fn) {
+      setTimeoutFunc(fn, 0);
+    };
+
+  Promise._unhandledRejectionFn = function _unhandledRejectionFn(err) {
+    if (typeof console !== 'undefined' && console) {
+      console.warn('Possible Unhandled Promise Rejection:', err); // eslint-disable-line no-console
+    }
+  };
+
+  /**
+   * Set the immediate function to execute callbacks
+   * @param fn {function} Function to execute
+   * @deprecated
+   */
+  Promise._setImmediateFn = function _setImmediateFn(fn) {
+    Promise._immediateFn = fn;
+  };
+
+  /**
+   * Change the function to execute on unhandled rejection
+   * @param {function} fn Function to execute on unhandled rejection
+   * @deprecated
+   */
+  Promise._setUnhandledRejectionFn = function _setUnhandledRejectionFn(fn) {
+    Promise._unhandledRejectionFn = fn;
+  };
+  
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Promise;
+  } else if (!root.Promise) {
+    root.Promise = Promise;
+  }
+
+})(this);


### PR DESCRIPTION
Works around a couple of bugs caused by users navigating around quickly (see #151 for reproduction scenarios).  Basically, this change ensures that JS assets are _definitely_ loaded before trying to execute inline scripts.

/cc @TheMallen, @qq99