### PR TITLE
Fix case of moving from a layout with tracked assets to one with none

### DIFF
--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -44,6 +44,9 @@ class window.TurboHead
       noMatchingSrc(node) || noMatchingHref(node)
     )
 
+  movingFromTrackedToUntracked: () ->
+    @upstreamAssets.length == 0 && @activeAssets.length > 0
+
   hasNamedAssetConflicts: () ->
     @newScripts
       .concat(@newLinks)
@@ -51,7 +54,9 @@ class window.TurboHead
       .some(datasetMatchesIn(TRACKED_ATTRIBUTE_NAME, @activeAssets))
 
   hasAssetConflicts: () ->
-    @hasNamedAssetConflicts() || @hasChangedAnonymousAssets()
+    @movingFromTrackedToUntracked() ||
+      @hasNamedAssetConflicts() ||
+      @hasChangedAnonymousAssets()
 
   waitForAssets: () ->
     resolvePreviousRequest?(isCanceled: true)

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -133,6 +133,12 @@ describe 'Turbolinks', ->
         done()
 
   describe 'head asset tracking', ->
+    it 'refreshes page when moving from a page with tracked assets to a page with none', (done) ->
+      startFromFixture('singleScriptInHead')
+      visit url: 'noScriptsOrLinkInHead', ->
+        assert(Turbolinks.fullPageNavigate.called, 'Should perform a full page refresh.')
+        done()
+
     it 'refreshes page when a data-turbolinks-track value matches but src changes', (done) ->
       startFromFixture('singleScriptInHead')
       visit url: 'singleScriptInHeadWithDifferentSourceButSameName', ->


### PR DESCRIPTION
This PR fixes #147

We'll be able to drop the workaround.

@Shopify/tnt 
@edward
@GoodForOneFare 
@utkarshsaxenashopify
