### PR TITLE
Fix/scroll reset

### DIFF
--- a/lib/assets/javascripts/turbograft/page.coffee
+++ b/lib/assets/javascripts/turbograft/page.coffee
@@ -15,18 +15,15 @@ Page.refresh = (options = {}, callback) ->
     location.pathname + paramString
   else
     location.href
+  delete options.url
 
+  options.partialReplace = true
+  options.callback = callback if callback
   if options.response
-    options.partialReplace = true
-    options.onLoadFunction = callback
-
     xhr = options.response
     delete options.response
     Turbolinks.loadPage null, xhr, options
   else
-    options.partialReplace = true
-    options.callback = callback if callback
-
     Turbolinks.visit newUrl, options
 
 Page.open = ->

--- a/test/javascripts/page_test.coffee
+++ b/test/javascripts/page_test.coffee
@@ -18,11 +18,10 @@ describe 'Page', ->
 
   describe '#refresh', ->
     it 'with opts.url', ->
-      Page.refresh
-        url: '/foo'
+      Page.refresh(url: '/foo')
 
-      assert @visitStub.calledOnce
-      assert @visitStub.calledWith "/foo", { url: '/foo', partialReplace: true }
+      assert(@visitStub.calledOnce, 'visit not called')
+      assert(@visitStub.calledWith("/foo", { partialReplace: true }), 'wrong parameters')
 
     it 'with opts.queryParams', ->
       Page.refresh
@@ -73,7 +72,7 @@ describe 'Page', ->
       , afterRefreshCallback
 
       assert loadPageStub.calledOnce
-      assert loadPageStub.calledWith null, xhrPlaceholder, { onlyKeys: ['a', 'b'], partialReplace: true, onLoadFunction: afterRefreshCallback }
+      assert loadPageStub.calledWith null, xhrPlaceholder, { onlyKeys: ['a', 'b'], partialReplace: true, callback: afterRefreshCallback }
       loadPageStub.restore()
 
     it 'updates window push state when response is a redirect', ->
@@ -92,7 +91,12 @@ describe 'Page', ->
         response: mockXHR,
         onlyKeys: ['a']
 
-      assert @replaceStateStub.calledWith sinon.match.any, '', mockXHR.getResponseHeader('X-XHR-Redirected-To')
+      assert.calledWith(
+        @replaceStateStub,
+        sinon.match.any,
+        '',
+        mockXHR.getResponseHeader('X-XHR-Redirected-To')
+      )
 
     it 'doens\'t update window push state if updatePushState is false', ->
 


### PR DESCRIPTION
## Summary
This PR fixes #149 and does some minor refactoring. Notably it simplifies the confusing dynamic between `onLoadFunction` and `callback` and moves `option` finagling closer to where the props are used (out of `fetch`). 

## Testing
Unfortunately, writing an automated test for this will not be possible until we make some changes to the test setup. This problem is related to #138, and #86, as we can't currently actually check scroll positions meaningfully in tests with our current setup.  ¯\_(ツ)_/¯

To 🎩  that this fixes the bug, click any card on home that triggers a redirect and observe the beautiful scroll reset.

You'll also want to at minimum make sure that:
- partial replaces do not reset scroll (play around on products or to make sure of this)
- full visits do reset scroll (scroll down a page and then click somewhere in the nav bar)
- tg-remotes do not reset scroll (pretty much any form in the admin)

**note: I want to significantly refactor the implementation of this fix after #144 merges, moving towards having the logic that cares about the xhr's data inside of the new `Request` object**

CC @Shopify/tnt 
@edward 
@GoodForOneFare 
@utkarshsaxenashopify
@qq99 