### PR TITLE
add a check for redirection before setting options.partialReplace

### DIFF
--- a/lib/assets/javascripts/turbograft/page.coffee
+++ b/lib/assets/javascripts/turbograft/page.coffee
@@ -17,7 +17,9 @@ Page.refresh = (options = {}, callback) ->
     location.href
 
   if options.response
-    options.partialReplace = true
+    followingARedirect = options.response.responseURL != newUrl
+    options.partialReplace = true unless followingARedirect
+
     options.onLoadFunction = callback
 
     xhr = options.response


### PR DESCRIPTION
This PR fixes #157.

When a remote action causes`Page.refresh` to be given a redirect, we now no longer mark it as a partial replace. This means that we gain head asset tracking and stop breaking stuff. Wooh.

This could have been a one line change but I wanted to make it more obvious why I was doing the check, hence the variable.

@Shopify/tnt 
@GoodForOneFare 
@qq99 
@edward 