### PR TITLE
`page:#script-error` => `page:script-error`

### DIFF
--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -125,7 +125,10 @@ insertScript = (activeDocument, scriptNode) ->
 
   scriptPromises[url] = new Promise((resolve) ->
     onAssetEvent = (event) ->
-      triggerEvent("page:#script-error", event) if event.type == 'error'
+      if event.type == 'error'
+        event.url = url
+        triggerEvent("page:script-error", event) if event.type == 'error'
+
       newNode.removeEventListener('load', onAssetEvent)
       newNode.removeEventListener('error', onAssetEvent)
       resolve()

--- a/lib/assets/javascripts/turbograft/turbohead.coffee
+++ b/lib/assets/javascripts/turbograft/turbohead.coffee
@@ -127,7 +127,7 @@ insertScript = (activeDocument, scriptNode) ->
     onAssetEvent = (event) ->
       if event.type == 'error'
         event.url = url
-        triggerEvent("page:script-error", event) if event.type == 'error'
+        triggerEvent("page:script-error", event)
 
       newNode.removeEventListener('load', onAssetEvent)
       newNode.removeEventListener('error', onAssetEvent)

--- a/test/javascripts/fake_script.coffee
+++ b/test/javascripts/fake_script.coffee
@@ -1,5 +1,5 @@
 window.fakeScript = (src) ->
-  listeners = []
+  listeners = {load: [], error: []}
   node = {
     'data-turbolinks-track': src
     attributes: [{name: 'src', value: src}]
@@ -15,11 +15,16 @@ window.fakeScript = (src) ->
       @attributes.push({name: name, value: value})
 
     addEventListener: (eventName, listener) ->
-      return if eventName != 'load'
-      listeners.push(listener)
+      listeners[eventName].push(listener)
+
+    fireError: () ->
+      listener({type: 'error'}) for listener in listeners['error']
+      new Promise (resolve) ->
+        node.isError = true
+        setTimeout -> resolve(node)
 
     fireLoaded: () ->
-      listener({type: 'load'}) for listener in listeners
+      listener({type: 'load'}) for listener in listeners['load']
       new Promise (resolve) ->
         node.isLoaded = true
         setTimeout -> resolve(node)

--- a/test/javascripts/fake_script.coffee
+++ b/test/javascripts/fake_script.coffee
@@ -20,7 +20,7 @@ window.fakeScript = (src) ->
     fireError: () ->
       listener({type: 'error'}) for listener in listeners['error']
       new Promise (resolve) ->
-        node.isError = true
+        node.hasError = true
         setTimeout -> resolve(node)
 
     fireLoaded: () ->

--- a/test/javascripts/turbohead_test.coffee
+++ b/test/javascripts/turbohead_test.coffee
@@ -11,7 +11,7 @@ describe 'TurboHead', ->
 
   nextUnloadedScript = ->
     unloaded = activeDocument.createdScripts.filter (script) ->
-      !script.isLoaded && !script.isError
+      !script.isLoaded && !script.hasError
     throw new Error('No unloaded scripts') if !unloaded[0]
 
     unloaded[0]
@@ -42,7 +42,7 @@ describe 'TurboHead', ->
         request.isInProgress = true
         request.isFulfilled = false
         request.isRejected = false
-        request.isError = false
+        request.hasError = false
         request
           .then (result) ->
             request.isInProgress = false


### PR DESCRIPTION
Fix an errant `#` in the `page:script-error` event (leftover from when this used to interpolate script/link types).

Also added a missing test to ensure that error scripts don't derail request fulfillment.

/cc @mallen, @Shopify/tnt 
