### PR TITLE
Fix remote redirects being all wonky

### DIFF
--- a/lib/assets/javascripts/turbograft/page.coffee
+++ b/lib/assets/javascripts/turbograft/page.coffee
@@ -16,18 +16,18 @@ Page.refresh = (options = {}, callback) ->
   else
     location.href
 
-  if options.response
-    options.partialReplace = true
-    options.onLoadFunction = callback
+  turboOptions = {
+    partialReplace: true,
+    exceptKeys: options.exceptKeys,
+    onlyKeys: options.onlyKeys,
+    updatePushState: options.updatePushState,
+    callback: callback
+  }
 
-    xhr = options.response
-    delete options.response
-    Turbolinks.loadPage null, xhr, options
+  if xhr = options.response
+    Turbolinks.loadPage null, xhr, turboOptions
   else
-    options.partialReplace = true
-    options.callback = callback if callback
-
-    Turbolinks.visit newUrl, options
+    Turbolinks.visit newUrl, turboOptions
 
 Page.open = ->
   window.open(arguments...)

--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -134,16 +134,19 @@ class TurboGraft.Remote
       else if @opts.fullRefresh
         Page.refresh()
       else if @refreshOnSuccess
-        Page.refresh
+        Page.refresh(
           response: xhr
           onlyKeys: @refreshOnSuccess
+        )
       else if @refreshOnSuccessExcept
-        Page.refresh
+        Page.refresh(
           response: xhr
           exceptKeys: @refreshOnSuccessExcept
+        )
       else
-        Page.refresh
+        Page.refresh(
           response: xhr
+        )
 
   onError: (ev) =>
     @opts.fail?()
@@ -162,13 +165,15 @@ class TurboGraft.Remote
       else if @opts.fullRefresh
         Page.refresh()
       else if @refreshOnError
-        Page.refresh
+        Page.refresh(
           response: xhr
           onlyKeys: @refreshOnError
+        )
       else if @refreshOnErrorExcept
-        Page.refresh
+        Page.refresh(
           response: xhr
           exceptKeys: @refreshOnErrorExcept
+        )
       else
         triggerEventFor 'turbograft:remote:fail:unhandled', @initiator,
           xhr: xhr

--- a/lib/assets/javascripts/turbograft/response.coffee
+++ b/lib/assets/javascripts/turbograft/response.coffee
@@ -1,5 +1,6 @@
 class TurboGraft.Response
   constructor: (@xhr) ->
+    @redirectedTo = @xhr.getResponseHeader('X-XHR-Redirected-To')
 
   valid: -> @hasRenderableHttpStatus() && @hasValidContent()
 
@@ -17,7 +18,15 @@ class TurboGraft.Response
     else
       throw new Error("Error encountered for XHR Response: #{this}")
 
+  redirectedToNewUrl: () ->
+    Boolean(
+      @redirectedTo &&
+      @redirectedTo != TurboGraft.location()
+    )
+
   toString: () ->
     "URL: #{@xhr.responseURL}, " +
     "ReadyState: #{@xhr.readyState}, " +
     "Headers: #{@xhr.getAllResponseHeaders()}"
+
+TurboGraft.location = () -> location.href

--- a/test/javascripts/fixtures/js/routes.coffee
+++ b/test/javascripts/fixtures/js/routes.coffee
@@ -17,6 +17,22 @@ window.ROUTES = {
     'error!'
   ],
 
+  xhrRedirectedToHeader: [
+    200,
+    {
+      'X-XHR-Redirected-To': 'test-location'
+    },
+    ''
+  ],
+
+  otherXhrRedirectedToHeader: [
+    200,
+    {
+      'X-XHR-Redirected-To': 'other-location'
+    },
+    ''
+  ],
+
   noScriptsOrLinkInHead: [
     200,
     {'Content-Type':'text/html'},

--- a/test/javascripts/initializers_test.coffee
+++ b/test/javascripts/initializers_test.coffee
@@ -22,8 +22,8 @@ describe 'Initializers', ->
       $("body").append($form)
       $form.find("input").trigger("click")
 
-      assert @Remote.called
-      assert @Remote.calledWith
+      assert.called(@Remote)
+      assert.calledWith(@Remote,
         httpRequestType: "put"
         httpUrl: "somewhere"
         fullRefresh: false
@@ -31,7 +31,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: "zap"
         refreshOnError: "bar"
         refreshOnErrorExcept: "zar"
-
+      )
       $form.remove()
 
   describe 'tg-remote on links', ->
@@ -42,25 +42,26 @@ describe 'Initializers', ->
       @Remote.restore()
 
     it 'creates a remote based on the options passed in', ->
-      $link = $("<a>")
-        .attr("tg-remote", "GET")
-        .attr("refresh-on-success", "foo")
-        .attr("refresh-on-error", "bar")
-        .attr("full-refresh-on-error-except", "zar")
-        .attr("full-refresh-on-success-except", "zap")
-        .attr("href", "somewhere")
+      $link = $('<a>')
+        .attr('tg-remote', 'GET')
+        .attr('refresh-on-success', 'foo')
+        .attr('refresh-on-error', 'bar')
+        .attr('full-refresh-on-error-except', 'zar')
+        .attr('full-refresh-on-success-except', 'zap')
+        .attr('href', 'somewhere')
 
-      $("body").append($link)
+      $('body').append($link)
       $link[0].click()
-      assert @Remote.called
-      assert @Remote.calledWith
-        httpRequestType: "GET"
-        httpUrl: "somewhere"
+      assert.called(@Remote)
+      assert.calledWith(@Remote,
+        httpRequestType: 'GET'
+        httpUrl: 'somewhere'
         fullRefresh: false
-        refreshOnSuccess: "foo"
-        refreshOnSuccessExcept: "zap"
-        refreshOnError: "bar"
-        refreshOnErrorExcept: "zar"
+        refreshOnSuccess: 'foo'
+        refreshOnSuccessExcept: 'zap'
+        refreshOnError: 'bar'
+        refreshOnErrorExcept: 'zar'
+      )
 
     it 'passes through null for missing refresh-on-success', ->
       $link = $("<a>")
@@ -70,8 +71,8 @@ describe 'Initializers', ->
 
       $("body").append($link)
       $link[0].click()
-      assert @Remote.called
-      assert @Remote.calledWith
+      assert.called(@Remote)
+      assert.calledWith(@Remote,
         httpRequestType: "GET"
         httpUrl: "somewhere"
         fullRefresh: false
@@ -79,6 +80,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
+      )
 
     it 'respects tg-remote supplied', ->
       $link = $("<a>")
@@ -88,8 +90,8 @@ describe 'Initializers', ->
 
       $("body").append($link)
       $link[0].click()
-      assert @Remote.called
-      assert @Remote.calledWith
+      assert.called(@Remote)
+      assert.calledWith(@Remote,
         httpRequestType: "PATCH"
         httpUrl: "somewhere"
         fullRefresh: false
@@ -97,6 +99,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
+      )
 
     it 'passes through null for missing refresh-on-error', ->
       $link = $("<a>")
@@ -106,8 +109,8 @@ describe 'Initializers', ->
 
       $("body").append($link)
       $link[0].click()
-      assert @Remote.called
-      assert @Remote.calledWith
+      assert.called(@Remote)
+      assert.calledWith(@Remote,
         httpRequestType: "GET"
         httpUrl: "somewhere"
         fullRefresh: false
@@ -115,6 +118,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: null
         refreshOnErrorExcept: null
+      )
 
     it 'passes through null for missing full-refresh-on-error-except', ->
       $link = $("<a>")
@@ -124,8 +128,8 @@ describe 'Initializers', ->
 
       $("body").append($link)
       $link[0].click()
-      assert @Remote.called
-      assert @Remote.calledWith
+      assert.called(@Remote)
+      assert.calledWith(@Remote,
         httpRequestType: "GET"
         httpUrl: "somewhere"
         fullRefresh: false
@@ -133,6 +137,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: null
         refreshOnErrorExcept: 'zew'
+      )
 
     it 'respects full-refresh-on-success-except', ->
       $link = $("<a>")
@@ -142,8 +147,8 @@ describe 'Initializers', ->
 
       $("body").append($link)
       $link[0].click()
-      assert @Remote.called
-      assert @Remote.calledWith
+      assert.called(@Remote)
+      assert.calledWith(@Remote,
         httpRequestType: "GET"
         httpUrl: "somewhere"
         fullRefresh: false
@@ -151,6 +156,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: 'zew'
         refreshOnError: null
         refreshOnErrorExcept: null
+      )
 
     it 'respects full-refresh', ->
       $link = $("<a>")
@@ -162,8 +168,8 @@ describe 'Initializers', ->
 
       $("body").append($link)
       $link[0].click()
-      assert @Remote.called
-      assert @Remote.calledWith
+      assert.called(@Remote)
+      assert.calledWith(@Remote,
         httpRequestType: "GET"
         httpUrl: "somewhere"
         fullRefresh: true
@@ -171,6 +177,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
+      )
 
     it 'does nothing if disabled', ->
       $link = $("<a>")
@@ -182,7 +189,7 @@ describe 'Initializers', ->
 
       $("body").append($link)
       $link[0].click()
-      assert.equal 0, @Remote.callCount
+      assert.notCalled(@Remote)
 
     it 'clicking on nodes inside of an <a> will bubble correctly', ->
       $link = $("<a><i>foo</i></a>")
@@ -194,8 +201,8 @@ describe 'Initializers', ->
 
       $("body").append($link)
       $i[0].click()
-      assert @Remote.called
-      assert @Remote.calledWith
+      assert.called(@Remote)
+      assert.calledWith(@Remote,
         httpRequestType: "PATCH"
         httpUrl: "somewhere"
         fullRefresh: false
@@ -203,6 +210,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
+      )
 
       $link.remove()
 
@@ -216,8 +224,8 @@ describe 'Initializers', ->
 
       $("body").append($link)
       $strong[0].click()
-      assert @Remote.called
-      assert @Remote.calledWith
+      assert.called(@Remote)
+      assert.calledWith(@Remote,
         httpRequestType: "PATCH"
         httpUrl: "somewhere"
         fullRefresh: false
@@ -225,5 +233,6 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
+      )
 
       $link.remove()

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -6,7 +6,6 @@ describe 'Remote', ->
     @initiating_target = $("<form />")[0]
 
   describe 'HTTP methods', ->
-
     it 'will send a GET with _method=GET', ->
       server = sinon.fakeServer.create()
       remote = new TurboGraft.Remote
@@ -68,7 +67,6 @@ describe 'Remote', ->
       assert.equal "POST", request.method
 
   describe 'callbacks', ->
-
     it 'will call options.fail() on HTTP failures', (done) ->
       server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
@@ -112,7 +110,6 @@ describe 'Remote', ->
       server.respond()
 
   describe 'TurboGraft events', ->
-
     beforeEach ->
       @refreshStub = stub(Page, "refresh")
 
@@ -482,7 +479,6 @@ describe 'Remote', ->
       assert.equal 0, @refreshStub.callCount
 
   describe 'serialization', ->
-
     it 'will create FormData by calling formDataAppend for each valid input', ->
       form = $("<form><input type='file' name='foo'><input type='text' name='bar' value='fizzbuzz'></form>")[0]
 

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -5,6 +5,7 @@ describe 'Turbolinks', ->
   sandbox = null
   pushStateStub = null
   replaceStateStub = null
+  resetScrollStub = null
 
   ROUTE_TEMPLATE_INDEX = 2
 
@@ -87,6 +88,7 @@ describe 'Turbolinks', ->
     sandbox = sinon.sandbox.create()
     pushStateStub = sandbox.stub(Turbolinks, 'pushState')
     replaceStateStub = sandbox.stub(Turbolinks, 'replaceState')
+    resetScrollStub = sandbox.stub(Turbolinks, 'resetScrollPosition')
     sandbox.stub(Turbolinks, 'fullPageNavigate', -> $(testDocument).trigger('page:load'))
     sandbox.useFakeServer()
 
@@ -141,6 +143,11 @@ describe 'Turbolinks', ->
       yourCallback = stub()
       visit url: 'noScriptsOrLinkInHead', options: {callback: yourCallback}, ->
         assert(yourCallback.calledOnce, 'Callback was not called.')
+        done()
+
+    it 'resets the scroll position', (done) ->
+      visit url: 'noScriptsOrLinkInHead', ->
+        assert.calledOnce(resetScrollStub)
         done()
 
   describe 'head asset tracking', ->
@@ -317,9 +324,19 @@ describe 'Turbolinks', ->
 
   describe 'with partial page replacement', ->
     beforeEach -> window.globalStub = stub()
+    it 'does not reset scroll position during partial replace', (done) ->
+      visit url: 'singleScriptInHead', options: {
+          partialReplace: true,
+          onlyKeys: ['turbo-area']
+        }, ->
+        assert.notCalled(resetScrollStub)
+        done()
 
     it 'head assets are not inserted during partial replace', (done) ->
-      visit url: 'singleScriptInHead', options: {partialReplace: true, onlyKeys: ['turbo-area']}, ->
+      visit url: 'singleScriptInHead', options: {
+            partialReplace: true,
+            onlyKeys: ['turbo-area']
+          }, ->
         assertScripts([])
         done()
 


### PR DESCRIPTION
## Summary
This PR fixes the two main issues (#157 and #149) with remotes that result in redirects ~~on an opt-in  basis~~, and also refactors some of `Turbolinks` to make it a bit easier to maintain (and to add these changes). 

## Details
As we can see with #157 and #149, remotes that result in redirects can be pretty sketchy in the current release of TG. In most cases, a remote resulting in a redirect is due to submitting a form and then being redirected to the html generating endpoint afterwards. This means that we want scroll position to not be affected, and we don't want to bother waiting on head asset tracking. However, some cases (see home card navigation) actually are page navigations in disguise. In these (exceptional) cases there is no elegant solution with the current build of TG and we are currently just forcing full page refreshes on them. 

## How?
- Adds a check for whether the `X-XHR-Redirect` header is pointing elsewhere, and considers the visit to be a non-partial replace if so. (This causes a scroll reset and triggers turbohead tracking)
- ~~Adds `tg-force-scroll-reset` as an optional attribute on remotes. `tg-force-scroll-reset='true'` will cause a scroll reset when the redirect navigation concludes.~~
- ~~Adds `tg-force-head-asset-insertion` as an optional attribute on remotes. `tg-force-head-asset-insertion='true'` will cause TG to perform head asset tracking just like a regular navigation, while still respecting partial replace rules that may have been set.~~
- Adds tests for scroll reset behaviour so that future contributors can better understand how it is intended to behave.
- Refactors with an emphasis on simplifying unnecessary forking and currying and iteratively rolling out proper sinon assertions (`assert @spy.called` => `assert.called @spy`)
- Leaves behaviour unchanged for other redirects 

## Reviewers: 
@edward 
@GoodForOneFare 
@qq99 
@Shopify/tnt 

**Edit**
Redid this from the ground up with a much simpler convention of simply counting redirects to another url to be non-partial replaces. No new syntax.
