### PR TITLE
client side redirect detection

### DIFF
--- a/lib/assets/javascripts/turbograft/response.coffee
+++ b/lib/assets/javascripts/turbograft/response.coffee
@@ -1,6 +1,11 @@
 class TurboGraft.Response
-  constructor: (@xhr) ->
-    @redirectedTo = @xhr.getResponseHeader('X-XHR-Redirected-To')
+  constructor: (@xhr, intendedURL) ->
+    if intendedURL && intendedURL != @xhr.responseURL
+      @redirectedTo = @xhr.responseURL
+    else
+      @redirectedTo = @xhr.getResponseHeader('X-XHR-Redirected-To')
+
+    @url = @redirectedTo || intendedURL
 
   valid: -> @hasRenderableHttpStatus() && @hasValidContent()
 

--- a/lib/assets/javascripts/turbograft/response.coffee
+++ b/lib/assets/javascripts/turbograft/response.coffee
@@ -5,7 +5,7 @@ class TurboGraft.Response
     else
       @redirectedTo = @xhr.getResponseHeader('X-XHR-Redirected-To')
 
-    @url = @redirectedTo || intendedURL
+    @finalURL = @redirectedTo || intendedURL
 
   valid: -> @hasRenderableHttpStatus() && @hasValidContent()
 

--- a/lib/assets/javascripts/turbograft/response.coffee
+++ b/lib/assets/javascripts/turbograft/response.coffee
@@ -1,6 +1,6 @@
 class TurboGraft.Response
   constructor: (@xhr, intendedURL) ->
-    if intendedURL && intendedURL != @xhr.responseURL
+    if intendedURL && intendedURL.withoutHash() != @xhr.responseURL
       @redirectedTo = @xhr.responseURL
     else
       @redirectedTo = @xhr.getResponseHeader('X-XHR-Redirected-To')

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -151,7 +151,6 @@ class window.Turbolinks
       return
 
     if options.partialReplace
-      reflectNewUrl url if options.updatePushState
       updateBody(upstreamDocument, response, options)
       return
 
@@ -159,7 +158,6 @@ class window.Turbolinks
     if turbohead.hasAssetConflicts()
       return Turbolinks.fullPageNavigate(response.url)
 
-    reflectNewUrl url if options.updatePushState
     turbohead.waitForAssets().then((result) ->
       updateBody(upstreamDocument, response, options) unless result?.isCanceled
     )
@@ -172,8 +170,8 @@ class window.Turbolinks
       'runScripts',
       options
     )
+    reflectNewUrl(response.url) if options.updatePushState
 
-    reflectRedirectedUrl(response) if options.updatePushState
     Turbolinks.resetScrollPosition() unless options.partialReplace
 
     options.callback?()

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -317,13 +317,6 @@ class window.Turbolinks
       Turbolinks.pushState { turbolinks: true, url: url.absolute }, '', url.absolute
     return
 
-  reflectRedirectedUrl = (response) ->
-    if url = response.redirectedTo
-      url = new ComponentUrl(url)
-      preservedHash = if url.hasNoHash() then activeDocument.location.hash else ''
-      Turbolinks.replaceState(currentState, '', url.href + preservedHash)
-    return
-
   rememberReferer = ->
     referer = activeDocument.location.href
 

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -1,3 +1,7 @@
+Response = TurboGraft.Response
+TurboHead = TurboGraft.TurboHead
+jQuery = window.jQuery
+
 xhr = null
 activeDocument = document
 
@@ -137,13 +141,13 @@ class window.Turbolinks
 
   @loadPage: (url, xhr, options = {}) ->
     triggerEvent 'page:receive'
-    response = new TurboGraft.Response(xhr)
+    response = new Response(xhr, url)
     options.updatePushState ?= true
     options.partialReplace = isPartialReplace(response, options)
 
     unless upstreamDocument = response.document()
       triggerEvent 'page:error', xhr
-      Turbolinks.fullPageNavigate(url)
+      Turbolinks.fullPageNavigate(response.url)
       return
 
     if options.partialReplace
@@ -151,9 +155,9 @@ class window.Turbolinks
       updateBody(upstreamDocument, response, options)
       return
 
-    turbohead = new TurboGraft.TurboHead(activeDocument, upstreamDocument)
+    turbohead = new TurboHead(activeDocument, upstreamDocument)
     if turbohead.hasAssetConflicts()
-      return Turbolinks.fullPageNavigate(url)
+      return Turbolinks.fullPageNavigate(response.url)
 
     reflectNewUrl url if options.updatePushState
     turbohead.waitForAssets().then((result) ->

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -147,7 +147,7 @@ class window.Turbolinks
 
     unless upstreamDocument = response.document()
       triggerEvent 'page:error', xhr
-      Turbolinks.fullPageNavigate(response.url)
+      Turbolinks.fullPageNavigate(response.finalURL)
       return
 
     if options.partialReplace
@@ -156,7 +156,7 @@ class window.Turbolinks
 
     turbohead = new TurboHead(activeDocument, upstreamDocument)
     if turbohead.hasAssetConflicts()
-      return Turbolinks.fullPageNavigate(response.url)
+      return Turbolinks.fullPageNavigate(response.finalURL)
 
     turbohead.waitForAssets().then((result) ->
       updateBody(upstreamDocument, response, options) unless result?.isCanceled
@@ -170,7 +170,7 @@ class window.Turbolinks
       'runScripts',
       options
     )
-    reflectNewUrl(response.url) if options.updatePushState
+    reflectNewUrl(response.finalURL) if options.updatePushState
 
     Turbolinks.resetScrollPosition() unless options.partialReplace
 

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -71,7 +71,7 @@ class window.Turbolinks
 
   fetch = (url, options = {}) ->
     return if pageChangePrevented(url)
-    url = new ComponentUrl url
+    url = new ComponentUrl(url)
 
     rememberReferer()
 

--- a/test/javascripts/page_test.coffee
+++ b/test/javascripts/page_test.coffee
@@ -1,12 +1,12 @@
 describe 'Page', ->
   sandbox = null
   visitStub = null
-  replaceStateStub = null
+  pushStateStub = null
 
   beforeEach ->
     sandbox = sinon.sandbox.create()
-    visitStub = sandbox.stub(Turbolinks, "visit")
-    replaceStateStub = sandbox.stub(Turbolinks, "replaceState")
+    visitStub = sandbox.stub(Turbolinks, 'visit')
+    pushStateStub = sandbox.stub(Turbolinks, 'pushState')
 
   afterEach ->
     sandbox.restore()
@@ -106,7 +106,7 @@ describe 'Page', ->
         onlyKeys: ['a'],
         }, ->
           assert.calledWith(
-            replaceStateStub,
+            pushStateStub,
             sinon.match.any,
             '',
             mockXHR.getResponseHeader('X-XHR-Redirected-To')
@@ -130,7 +130,7 @@ describe 'Page', ->
         onlyKeys: ['a']
         updatePushState: false,
         }, ->
-          assert.notCalled(replaceStateStub)
+          assert.notCalled(pushStateStub)
           done()
       )
 

--- a/test/javascripts/response_test.coffee
+++ b/test/javascripts/response_test.coffee
@@ -3,14 +3,14 @@ describe 'TurboGraft.Response', ->
   iframe = null
   baseHTML = '<html><head></head><body></body></html>'
 
-  responseForFixture = (fixture, callback) ->
+  responseForFixture = ({fixture, intendedURL=null}, callback) ->
     xhr = new XMLHttpRequest
     xhr.open("GET", "/#{fixture}", true)
     xhr.send()
     xhr.onload = ->
-      callback(new TurboGraft.Response(xhr))
+      callback(new TurboGraft.Response(xhr, intendedURL))
     xhr.onerror = ->
-      callback(new TurboGraft.Response(xhr))
+      callback(new TurboGraft.Response(xhr, intendedURL))
 
   setupIframe = ->
     iframe = document.createElement('iframe')
@@ -35,40 +35,45 @@ describe 'TurboGraft.Response', ->
 
   describe 'valid', ->
     it 'returns false when a server error is encountered', (done) ->
-      responseForFixture 'serverError', (response) ->
+      responseForFixture { fixture: 'serverError' }, (response) ->
         assert(!response.valid(), 'response should not be valid when an error is received')
         done()
 
     it 'returns true when a 422 error is encountered', (done) ->
-      responseForFixture 'validationError', (response) ->
+      responseForFixture { fixture: 'validationError' }, (response) ->
         assert(response.valid(), 'response should be valid when a 422 error is received')
         done()
 
     it 'returns true when a success status is encountered', (done) ->
-      responseForFixture 'noScriptsOrLinkInHead', (response) ->
+      responseForFixture { fixture: 'noScriptsOrLinkInHead' }, (response) ->
         assert(response.valid(), 'response should be valid when a 200 is received')
         done()
 
     it 'throws an error when Content-Type is empty', (done) ->
-      responseForFixture 'noContentType', (response) ->
+      responseForFixture { fixture: 'noContentType' }, (response) ->
         assert.throws(response.valid)
         done()
 
   describe 'document', ->
     it 'returns TurboGraft.Document.create when valid', (done) ->
       stub = sandbox.stub(TurboGraft.Document, 'create', -> 'document')
-      responseForFixture 'noScriptsOrLinkInHead', (response) ->
+      responseForFixture { fixture: 'noScriptsOrLinkInHead' }, (response) ->
         assert.equal(response.document(), 'document')
         done()
 
     it 'returns undefined when invalid', (done) ->
-      responseForFixture 'serverError', (response) ->
+      responseForFixture { fixture: 'serverError' }, (response) ->
         assert.equal(response.document(), undefined)
         done()
 
   describe 'redirectedTo', ->
-    it 'returns the value of the X-XHR-Redirected-To header', (done) ->
-      responseForFixture 'xhrRedirectedToHeader', (response) ->
+    it 'returns the responseURL if intendedURL is present and responseURL is different from passed in url', ->
+      responseForFixture { fixture: 'noScriptsOrLinkInHead', intendedURL: 'test-url' }, (response) ->
+        assert.equal(response.redirectedTo, 'noScriptsOrLinkInHead')
+        done()
+
+    it 'returns the value of the X-XHR-Redirected-To header when present', (done) ->
+      responseForFixture { fixture: 'xhrRedirectedToHeader' }, (response) ->
         assert.equal(response.redirectedTo, ROUTES['xhrRedirectedToHeader'][1]['X-XHR-Redirected-To'])
         done()
 
@@ -77,16 +82,16 @@ describe 'TurboGraft.Response', ->
       sandbox.stub(TurboGraft, 'location', -> 'test-location')
 
     it 'returns false when no redirect header is present', (done) ->
-      responseForFixture 'noScriptsOrLnkInHead', (response) ->
+      responseForFixture { fixture: 'noScriptsOrLnkInHead' }, (response) ->
         assert(!response.redirectedToNewUrl(), 'response should report that it was redirected to a new url when it has no redirect header')
         done()
 
     it 'returns false when a redirect header is present but matches location.href', (done) ->
-      responseForFixture 'xhrRedirectedToHeader', (response) ->
+      responseForFixture { fixture: 'xhrRedirectedToHeader' }, (response) ->
         assert.equal(response.redirectedToNewUrl(), false)
         done()
 
     it 'returns true when a redirect header is present and does not match location.href', (done) ->
-      responseForFixture 'otherXhrRedirectedToHeader', (response) ->
+      responseForFixture { fixture: 'otherXhrRedirectedToHeader' }, (response) ->
         assert.equal(response.redirectedToNewUrl(), true)
         done()

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -438,10 +438,10 @@ describe 'Turbolinks', ->
 
     it 'does not update document if the request was canceled', ->
       resolver({isCanceled: true})
-      loadPromise = Turbolinks.loadPage('/foo', xhr)
+      loadPromise = Turbolinks.loadPage(new ComponentUrl('/foo'), xhr)
         .then -> assert.notInclude(testDocument.body.innerHTML, SUCCESS_HTML_CONTENT)
 
     it 'updates the document if the request was not canceled', ->
       resolver()
-      loadPromise = Turbolinks.loadPage('/foo', xhr)
+      loadPromise = Turbolinks.loadPage(new ComponentUrl('/foo'), xhr)
         .then -> assert.include(testDocument.body.innerHTML, SUCCESS_HTML_CONTENT)


### PR DESCRIPTION
## Summary
- adds a new check that determines redirect status on the client side using `xhr.responseURL` vs our known`intendedURL`
- memoizes `url` onto the `Response` object 
- simplifies browser state updates using `Response.url`
## Why tho

Basically, in some cases we were causing the server to do extra work. It turns out this becomes more apparent when service workers get involved, because you need to know what URL you're actually going to and you can't know it will be a redirect first and... ok well it's hard to explain why but let me tell you it was breaking something fierce.

Imagine if you will, you go to do a thing, and you get redirected. Lucky you, this also happens to be right when we push a new bundle. ATM the following happens:
- TG makes an xhr to the url you wanted, and stores this url
- The server does things and sends a redirect
- Browser follows this automagically
- TG receives the response from the redirect
- TG checks the head assets and decides to reload the page **BUT, it uses the original url you wanted**
- The Browser navigates to the url you wanted
- The server does things (again) and sends a redirect (again, maybe, hopefully I guess)
- The Browser follows this automagically

This usually hasn't been an issue for us because most of our redirects are through `Remote` which... doesn't give a url to `Page`. This is probably why we used to have so many exceptions out of `Turbolinks` related to trying to `fullPageNavigate` to a null url. Anyways, it breaks my service worker implementation (causes an infinite redirection loop actually) as well as just being wasteful and possibly triggering server work multiple times for no reason.
## What why do we need `X-XHR-Redirected-To` then?

The short answer is we don't. The long answer is that `Remote` is hiding the url it's trying to go to from our friends `Page` and `Turbolinks`. It could be a large-ish refactor involving a test murdering spree to make that not the case, so I'll leave that for the future for now. 
## Wait why did you remove the use of `reflectRedirectedUrl`

As far as I could tell the flow was basically
- always push the new state onto the history stack (can happen in 2 places)
- if we have a redirect header replace the top entry with the redirect header's url (later)

The result of this is the same as
- determine the canonical url to push
- push the url
## Tophatting

I tophatted a lot with these changes. But it should be tophatted more for sure. I'd recommend going to lots of forms, logging out and heading back to pages of the admin, going to theme editor, and just generally making a muck of things and causing redirects allover the place.
## Reviewers

@lemonmade 
@qq99
@qq99

CC @Shopify/tnt 
