### PR TITLE
refactor remote tests to use iframe

### DIFF
--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -1,7 +1,18 @@
+baseHTML = '<html><head></head><body></body></html>'
+iframe = null
+
+setupIframe = ->
+  iframe = document.createElement('iframe')
+  document.body.appendChild(iframe)
+  iframe.contentDocument.write(baseHTML)
+  iframe.contentDocument
+
 describe 'Remote', ->
   @initiating_target = null
 
   beforeEach ->
+    testDocument = setupIframe() unless iframe
+    Turbolinks.document(testDocument)
     $(document).off "turbograft:remote:start turbograft:remote:always turbograft:remote:success turbograft:remote:fail turbograft:remote:fail:unhandled"
     @initiating_target = $("<form />")[0]
 

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -11,7 +11,7 @@ describe 'Remote', ->
   @initiating_target = null
 
   beforeEach ->
-    testDocument = setupIframe() unless iframe
+    testDocument = setupIframe()
     Turbolinks.document(testDocument)
     $(document).off "turbograft:remote:start turbograft:remote:always turbograft:remote:success turbograft:remote:fail turbograft:remote:fail:unhandled"
     @initiating_target = $("<form />")[0]

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -83,7 +83,7 @@ describe 'Turbolinks', ->
     Turbolinks.visit('/' + url, options)
 
   beforeEach ->
-    testDocument = setupIframe() unless iframe
+    testDocument = setupIframe()
     Turbolinks.document(testDocument)
     sandbox = sinon.sandbox.create()
     pushStateStub = sandbox.stub(Turbolinks, 'pushState')


### PR DESCRIPTION
This test makes remote test browser runner friendly by sandboxing TG into an iframe just like in the other tests. :)

@Shopify/tnt 
@GoodForOneFare 
@lemonmade 
