### PR TITLE
Fix broken travis scripts, plug up ensuing test leaks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,25 @@
+addons:
+  firefox: "49.0.2"
+
 language: ruby
+sudo: false
+
+cache:
+  directories:
+    - "travis_geckodriver"
+
 rvm:
   - '2.3.1'
+
 before_script:
+  - if [ ! -d $PWD/travis_geckodriver ];  then mkdir $PWD/travis_geckodriver; fi
+  - if [ ! -f $PWD/travis_geckodriver/geckodriver ]; then wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz; fi
+  - if [ ! -f $PWD/travis_geckodriver/geckodriver ]; then tar -xvf geckodriver-v0.11.1-linux64.tar.gz -C $PWD/travis_geckodriver; fi
+  - "export PATH=$PWD/travis_geckodriver:$PATH"
+  - "geckodriver --version"
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - sleep 3
   - bundle install
+
 script: bundle exec rake ci

--- a/test/browser/full_page_refresh_test.rb
+++ b/test/browser/full_page_refresh_test.rb
@@ -5,6 +5,7 @@ class FullPageRefreshTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
 
   setup do
+    reset_session!
     visit "/pages/1"
   end
 

--- a/test/browser/legacy_full_page_refresh_test.rb
+++ b/test/browser/legacy_full_page_refresh_test.rb
@@ -5,6 +5,7 @@ class LegacyPagesFullPageRefreshTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
 
   setup do
+    reset_session!
     visit "/legacy_pages/1"
   end
 

--- a/test/browser/legacy_pages_request_test.rb
+++ b/test/browser/legacy_pages_request_test.rb
@@ -5,8 +5,11 @@ class LegacyPagesPageRequestTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
   include Capybara::Node::Matchers
 
-  test "turbolinks works" do
+  setup do
+    reset_session!
+  end
 
+  test "turbolinks works" do
     visit "/legacy_pages/1"
     tracking_token = find(:css, "meta[name='tracking-token']", visible: false)[:content]
 

--- a/test/browser/legacy_partial_page_refresh_test.rb
+++ b/test/browser/legacy_partial_page_refresh_test.rb
@@ -5,6 +5,7 @@ class LegacyPagesPartialPageRefreshTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
 
   setup do
+    reset_session!
     visit "/legacy_pages/1"
   end
 

--- a/test/browser/pages_request_test.rb
+++ b/test/browser/pages_request_test.rb
@@ -5,8 +5,11 @@ class PageRequestTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
   include Capybara::Node::Matchers
 
-  test "turbolinks works" do
+  setup do
+    reset_session!
+  end
 
+  test "turbolinks works" do
     visit "/pages/1"
     tracking_token = find(:css, "meta[name='tracking-token']", visible: false)[:content]
 

--- a/test/browser/partial_page_refresh_test.rb
+++ b/test/browser/partial_page_refresh_test.rb
@@ -5,6 +5,7 @@ class PartialPageRefreshTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
 
   setup do
+    reset_session!
     visit "/pages/1"
   end
 

--- a/test/example/app/assets/javascripts/application.js
+++ b/test/example/app/assets/javascripts/application.js
@@ -12,5 +12,6 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require_tree ./vendor
 //= require turbograft
 //= require_tree .

--- a/test/example/app/assets/javascripts/vendor/promise-polyfill/promise.js
+++ b/test/example/app/assets/javascripts/vendor/promise-polyfill/promise.js
@@ -1,0 +1,233 @@
+(function (root) {
+
+  // Store setTimeout reference so promise-polyfill will be unaffected by
+  // other code modifying setTimeout (like sinon.useFakeTimers())
+  var setTimeoutFunc = setTimeout;
+
+  function noop() {}
+  
+  // Polyfill for Function.prototype.bind
+  function bind(fn, thisArg) {
+    return function () {
+      fn.apply(thisArg, arguments);
+    };
+  }
+
+  function Promise(fn) {
+    if (typeof this !== 'object') throw new TypeError('Promises must be constructed via new');
+    if (typeof fn !== 'function') throw new TypeError('not a function');
+    this._state = 0;
+    this._handled = false;
+    this._value = undefined;
+    this._deferreds = [];
+
+    doResolve(fn, this);
+  }
+
+  function handle(self, deferred) {
+    while (self._state === 3) {
+      self = self._value;
+    }
+    if (self._state === 0) {
+      self._deferreds.push(deferred);
+      return;
+    }
+    self._handled = true;
+    Promise._immediateFn(function () {
+      var cb = self._state === 1 ? deferred.onFulfilled : deferred.onRejected;
+      if (cb === null) {
+        (self._state === 1 ? resolve : reject)(deferred.promise, self._value);
+        return;
+      }
+      var ret;
+      try {
+        ret = cb(self._value);
+      } catch (e) {
+        reject(deferred.promise, e);
+        return;
+      }
+      resolve(deferred.promise, ret);
+    });
+  }
+
+  function resolve(self, newValue) {
+    try {
+      // Promise Resolution Procedure: https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure
+      if (newValue === self) throw new TypeError('A promise cannot be resolved with itself.');
+      if (newValue && (typeof newValue === 'object' || typeof newValue === 'function')) {
+        var then = newValue.then;
+        if (newValue instanceof Promise) {
+          self._state = 3;
+          self._value = newValue;
+          finale(self);
+          return;
+        } else if (typeof then === 'function') {
+          doResolve(bind(then, newValue), self);
+          return;
+        }
+      }
+      self._state = 1;
+      self._value = newValue;
+      finale(self);
+    } catch (e) {
+      reject(self, e);
+    }
+  }
+
+  function reject(self, newValue) {
+    self._state = 2;
+    self._value = newValue;
+    finale(self);
+  }
+
+  function finale(self) {
+    if (self._state === 2 && self._deferreds.length === 0) {
+      Promise._immediateFn(function() {
+        if (!self._handled) {
+          Promise._unhandledRejectionFn(self._value);
+        }
+      });
+    }
+
+    for (var i = 0, len = self._deferreds.length; i < len; i++) {
+      handle(self, self._deferreds[i]);
+    }
+    self._deferreds = null;
+  }
+
+  function Handler(onFulfilled, onRejected, promise) {
+    this.onFulfilled = typeof onFulfilled === 'function' ? onFulfilled : null;
+    this.onRejected = typeof onRejected === 'function' ? onRejected : null;
+    this.promise = promise;
+  }
+
+  /**
+   * Take a potentially misbehaving resolver function and make sure
+   * onFulfilled and onRejected are only called once.
+   *
+   * Makes no guarantees about asynchrony.
+   */
+  function doResolve(fn, self) {
+    var done = false;
+    try {
+      fn(function (value) {
+        if (done) return;
+        done = true;
+        resolve(self, value);
+      }, function (reason) {
+        if (done) return;
+        done = true;
+        reject(self, reason);
+      });
+    } catch (ex) {
+      if (done) return;
+      done = true;
+      reject(self, ex);
+    }
+  }
+
+  Promise.prototype['catch'] = function (onRejected) {
+    return this.then(null, onRejected);
+  };
+
+  Promise.prototype.then = function (onFulfilled, onRejected) {
+    var prom = new (this.constructor)(noop);
+
+    handle(this, new Handler(onFulfilled, onRejected, prom));
+    return prom;
+  };
+
+  Promise.all = function (arr) {
+    var args = Array.prototype.slice.call(arr);
+
+    return new Promise(function (resolve, reject) {
+      if (args.length === 0) return resolve([]);
+      var remaining = args.length;
+
+      function res(i, val) {
+        try {
+          if (val && (typeof val === 'object' || typeof val === 'function')) {
+            var then = val.then;
+            if (typeof then === 'function') {
+              then.call(val, function (val) {
+                res(i, val);
+              }, reject);
+              return;
+            }
+          }
+          args[i] = val;
+          if (--remaining === 0) {
+            resolve(args);
+          }
+        } catch (ex) {
+          reject(ex);
+        }
+      }
+
+      for (var i = 0; i < args.length; i++) {
+        res(i, args[i]);
+      }
+    });
+  };
+
+  Promise.resolve = function (value) {
+    if (value && typeof value === 'object' && value.constructor === Promise) {
+      return value;
+    }
+
+    return new Promise(function (resolve) {
+      resolve(value);
+    });
+  };
+
+  Promise.reject = function (value) {
+    return new Promise(function (resolve, reject) {
+      reject(value);
+    });
+  };
+
+  Promise.race = function (values) {
+    return new Promise(function (resolve, reject) {
+      for (var i = 0, len = values.length; i < len; i++) {
+        values[i].then(resolve, reject);
+      }
+    });
+  };
+
+  // Use polyfill for setImmediate for performance gains
+  Promise._immediateFn = (typeof setImmediate === 'function' && function (fn) { setImmediate(fn); }) ||
+    function (fn) {
+      setTimeoutFunc(fn, 0);
+    };
+
+  Promise._unhandledRejectionFn = function _unhandledRejectionFn(err) {
+    if (typeof console !== 'undefined' && console) {
+      console.warn('Possible Unhandled Promise Rejection:', err); // eslint-disable-line no-console
+    }
+  };
+
+  /**
+   * Set the immediate function to execute callbacks
+   * @param fn {function} Function to execute
+   * @deprecated
+   */
+  Promise._setImmediateFn = function _setImmediateFn(fn) {
+    Promise._immediateFn = fn;
+  };
+
+  /**
+   * Change the function to execute on unhandled rejection
+   * @param {function} fn Function to execute on unhandled rejection
+   * @deprecated
+   */
+  Promise._setUnhandledRejectionFn = function _setUnhandledRejectionFn(fn) {
+    Promise._unhandledRejectionFn = fn;
+  };
+  
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Promise;
+  } else if (!root.Promise) {
+    root.Promise = Promise;
+  }
+
+})(this);

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,7 @@ require File.expand_path('../example/config/environment.rb',  __FILE__)
 require 'rails/test_help'
 
 Capybara.app = Example::Application
-Capybara.current_driver = :selenium
+Capybara.current_driver = ENV['CAPYBARA_DRIVER'] || :selenium
 Capybara.default_max_wait_time = 2
 
 Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new(color: true))

--- a/turbograft.gemspec
+++ b/turbograft.gemspec
@@ -6,10 +6,10 @@ require 'turbograft/version'
 Gem::Specification.new do |spec|
   spec.name          = "turbograft"
   spec.version       = TurboGraft::VERSION
-  spec.authors       = ["Kristian Plettenberg-Dussault", "Justin Li", "Nicholas Simmons", "Tyler Mercier", "Anthony Cameron", "Patrick Donovan"]
-  spec.email         = ["tylermercier@gmail.com"]
+  spec.authors       = ["Kristian Plettenberg-Dussault", "Justin Li", "Nicholas Simmons", "Tyler Mercier", "Anthony Cameron", "Patrick Donovan", "Mathew Allen", "Gord Pearson"]
+  spec.email         = ["tylermercier@gmail.com", "mathew.allen@shopify.com"]
   spec.summary       = "turbolinks with partial page replacement"
-  spec.description   = "It's like turbolinks, but with partial page replacement and tests"
+  spec.description   = "Turbograft is a hard fork of Turbolinks, allowing you to perform partial page refreshes and offering ajax form utilities."
   spec.homepage      = "https://github.com/Shopify/turbograft"
   spec.license       = "MIT"
 


### PR DESCRIPTION
**Fixes #169 (hopefully?)**
~~We just export an environment variable. TBH I'm not sure how this was ever working if travis never had selenium.~~

This was funny. 
- Travis suddenly lacked selenium drivers for FF
- Tried to switch to phantom
  - Worked great for js tests
  - Didn't work for ruby tests
- Switched ruby tests back to selenium and worked on getting it working
  - Had to install geckodriver in the before_script hook
  - Had to request a modern firefox build
- Ran into leaky tests (possibly exposed by newer FF build or something?) where test order randomization would cause fails sometimes due to session persistence and our server side TG shenanigans.
  - Added `session_reset` logic to fix them
- Had a hilarious number of fails (and thus test restarts) caused by our silly test that compares two random numbers to eachother. I'm not really sure how to fix that test without a larger test restructure so I'm going to leave it for now. (*sigh*). In theory it should be like a million in one chance but there must be something funky happening in the RNG to make it more likely. (shared seeds?)

@Shopify/tnt 
@qq99 
@lemonmade
@GoodForOneFare 
