### PR TITLE
Allow to configure Turbogradft in a way that doesn't compromise lazy loading

### DIFF
--- a/lib/turbograft.rb
+++ b/lib/turbograft.rb
@@ -14,16 +14,20 @@ module TurboGraft
     self.controllers = ["ActionController::Base"]
   end
 
+  def self.included(controller)
+    controller.class_eval do
+      include XHRHeaders, Cookies, XDomainBlocker, Redirection
+      before_action :set_xhr_redirected_to, :set_request_method_cookie
+      after_action :abort_xdomain_redirect
+    end
+  end
+
   class Engine < ::Rails::Engine
 
     initializer :turbograft do |config|
       ActiveSupport.on_load(:action_controller) do
-        Config.controllers.each do |klass|
-          klass.constantize.class_eval do
-            include XHRHeaders, Cookies, XDomainBlocker, Redirection
-            before_action :set_xhr_redirected_to, :set_request_method_cookie
-            after_action :abort_xdomain_redirect
-          end
+        Config.controllers.each do |class_name|
+          class_name.constantize.include(::TurboGraft)
         end
 
         ActionDispatch::Request.class_eval do


### PR DESCRIPTION
Currently, if you customize `TurboGraft::Config.controllers`, the listed controllers will be eager loaded.

This is detrimental in big apps, because it will slow down the boot in development mode for no good reason.

This PR allows alternatively to explicitly `include TurboGraft` in the controllers you want it, and it will only take effect when the controller is referenced.

@qq99 @TheMallen @rafaelfranca for review please.