### PR TITLE
Have visit return a promise, add associated test

### DIFF
--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -389,6 +389,17 @@ describe 'Turbolinks', ->
         assert.include(testDocument.body.textContent, 'Hi bob')
         done()
 
+    it 'returns a promise resolved with a list of nodes that are new (freshly replaced)', (done) ->
+      visit(url: 'noScriptsOrLinkInHead', options: {partialReplace: true, onlyKeys: ['turbo-area']})
+        .then (nodes) ->
+          assert.instanceOf(nodes, Array)
+          assert.lengthOf(nodes, 1)
+          node = nodes[0]
+
+          assert.equal('turbo-area', node.id)
+          assert.equal('turbo-area', node.getAttribute('refresh'))
+          done()
+
     it 'triggers the page:load event with a list of nodes that are new (freshly replaced)', (done) ->
       visit url: 'noScriptsOrLinkInHead', options: {partialReplace: true, onlyKeys: ['turbo-area']}, (event) ->
         ev = event.originalEvent


### PR DESCRIPTION
## Problem
This PR adds promise support for running code after a replace has occurred. We currently offer other ways of doing this, such as passing a callback to `Page.replace` or adding an event listener for `page:load`, however these apis are more developer-hostile and in real life we've seen things like this:

```
# someform.coffee (line 200)
    operation = $.ajax(.....)

    operation.done (data, status, xhr) ->
        Page.refresh response: xhr

    @saveOperation = operation

# someform.coffee (line 300)
    @saveOperation.done (data) ->
        doSomeOperationsThatRequireTGToBeDoneDoingItsThing()
```

Developers keep the ajax object around so that later parts of the program can dynamically add listeners to them. **Unfortunately, this doesn't always work.** Since TG's `loadPage` operation is only synchronous when we don't have to update head assets, **you cannot garauntee that a later `done` callback on the ajax object will be executed after TG is done updating the page**. This can cause some crazy issues.

Of course, the dev could build their own promise or other object to manage `page:load` callbacks, but this is a lot of boilerplate.

## Solution
We are already sometimes returning a promise (more or less accidentally) from `loadPage`. Let's just always do so. This lets code simply switch to storing the promise result from `refresh` or `visit`, and involves minimal changes and no api breakage. In the future, we could even make `loadPage` work with `Response` objects returned by `fetch`.

```
# someform.coffee (line 300)
    @saveOperation.then (data) ->
        doSomeOperationsThatRequireTGToBeDoneDoingItsThing()
```

@lemonmade 
@GoodForOneFare 
@Shopify/byroot 