### PR TITLE
Add support for tg-remote-nopushstate, letting user choose whether or not to update URL after tg-remote redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ It requires your `<form>`, `<a>`, or `<button>` to be marked up with:
 * `data-tg-remote-once`: (optional) The action will only be performed once. Removes `data-tg-remote-method` and `data-tg-remote-once` from element after consumption
 * `data-tg-full-refresh`: Rather than using the content of the XHR response for partial page replacement, a full page refresh is performed. If `data-tg-refresh-on-success` or `data-tg-refresh-on-error` is defined, the page will be reloaded on those keys. If both `data-tg-refresh-on-success` and `data-tg-refresh-on-error` are not defined, a full page refresh is performed. Defaults to true if neither refresh-on-success nor refresh-on-error are provided
 * `data-tg-remote-norefresh`: Prevents `Page.refresh()` from being called, allowing methods to be executed without updating client state
+* `data-tg-remote-nopushstate`: If present, prevents tg-remotes from updating the URL state of the browser.  The default behaviour is to update the URL if it changes, e.g. during an HTTP302 redirect.
 
 Note that as `data-tg-refresh-on-*` pertains to partial refreshes and `data-tg-full-refresh-on-*-except` pertains to full refreshes, they are incompatible with each other and should not be combined.
 

--- a/lib/assets/javascripts/turbograft/initializers.coffee
+++ b/lib/assets/javascripts/turbograft/initializers.coffee
@@ -21,6 +21,7 @@ setupRemoteFromTarget = (target, httpRequestType, form = null) ->
     refreshOnSuccessExcept: TurboGraft.getTGAttribute(target, 'full-refresh-on-success-except')
     refreshOnError: TurboGraft.getTGAttribute(target, 'refresh-on-error')
     refreshOnErrorExcept: TurboGraft.getTGAttribute(target, 'full-refresh-on-error-except')
+    updatePushState: !TurboGraft.hasTGAttribute(target, 'tg-remote-nopushstate')
 
   new TurboGraft.Remote(options, form, target)
 

--- a/lib/assets/javascripts/turbograft/remote.coffee
+++ b/lib/assets/javascripts/turbograft/remote.coffee
@@ -12,6 +12,8 @@ class TurboGraft.Remote
     @refreshOnSuccessExcept = @opts.refreshOnSuccessExcept.split(" ") if @opts.refreshOnSuccessExcept
     @refreshOnError         = @opts.refreshOnError.split(" ")         if @opts.refreshOnError
     @refreshOnErrorExcept   = @opts.refreshOnErrorExcept.split(" ")   if @opts.refreshOnErrorExcept
+    @updatePushState        = true
+    @updatePushState        = @opts.updatePushState                   if @opts.updatePushState?
 
     xhr = new XMLHttpRequest
     if @actualRequestType == 'GET'
@@ -116,6 +118,12 @@ class TurboGraft.Remote
       enabledInputs.push(input)
     enabledInputs
 
+  refresh: (options) =>
+    opts = $.extend({
+      updatePushState: @updatePushState
+    }, options);
+    Page.refresh(opts);
+
   onSuccess: (ev) =>
     @opts.success?()
 
@@ -130,21 +138,21 @@ class TurboGraft.Remote
 
     unless TurboGraft.hasTGAttribute(@initiator, 'tg-remote-norefresh')
       if @opts.fullRefresh && @refreshOnSuccess
-        Page.refresh(onlyKeys: @refreshOnSuccess)
+        @refresh(onlyKeys: @refreshOnSuccess)
       else if @opts.fullRefresh
-        Page.refresh()
+        @refresh()
       else if @refreshOnSuccess
-        Page.refresh(
+        @refresh(
           response: xhr
           onlyKeys: @refreshOnSuccess
         )
       else if @refreshOnSuccessExcept
-        Page.refresh(
+        @refresh(
           response: xhr
           exceptKeys: @refreshOnSuccessExcept
         )
       else
-        Page.refresh(
+        @refresh(
           response: xhr
         )
 
@@ -161,16 +169,16 @@ class TurboGraft.Remote
         xhr: xhr
     else
       if @opts.fullRefresh && @refreshOnError
-        Page.refresh(onlyKeys: @refreshOnError)
+        @refresh(onlyKeys: @refreshOnError)
       else if @opts.fullRefresh
-        Page.refresh()
+        @refresh()
       else if @refreshOnError
-        Page.refresh(
+        @refresh(
           response: xhr
           onlyKeys: @refreshOnError
         )
       else if @refreshOnErrorExcept
-        Page.refresh(
+        @refresh(
           response: xhr
           exceptKeys: @refreshOnErrorExcept
         )

--- a/test/javascripts/initializers_test.coffee
+++ b/test/javascripts/initializers_test.coffee
@@ -31,6 +31,35 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: "zap"
         refreshOnError: "bar"
         refreshOnErrorExcept: "zar"
+        updatePushState: true
+      )
+      $form.remove()
+
+    it 'passes through updatePushState=false if tg-remote-nopushstate', ->
+      $form = $("<form>")
+        .attr("tg-remote", "true")
+        .attr("method", "put")
+        .attr("refresh-on-success", "foo")
+        .attr("refresh-on-error", "bar")
+        .attr("full-refresh-on-error-except", "zar")
+        .attr("full-refresh-on-success-except", "zap")
+        .attr("tg-remote-nopushstate", "")
+        .attr("action", "somewhere")
+      $form.append("<input type='submit'>")
+
+      $("body").append($form)
+      $form.find("input").trigger("click")
+
+      assert.called(@Remote)
+      assert.calledWith(@Remote,
+        httpRequestType: "put"
+        httpUrl: "somewhere"
+        fullRefresh: false
+        refreshOnSuccess: "foo"
+        refreshOnSuccessExcept: "zap"
+        refreshOnError: "bar"
+        refreshOnErrorExcept: "zar"
+        updatePushState: false
       )
       $form.remove()
 
@@ -61,6 +90,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: 'zap'
         refreshOnError: 'bar'
         refreshOnErrorExcept: 'zar'
+        updatePushState: true
       )
 
     it 'passes through null for missing refresh-on-success', ->
@@ -80,6 +110,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
+        updatePushState: true
       )
 
     it 'respects tg-remote supplied', ->
@@ -99,6 +130,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
+        updatePushState: true
       )
 
     it 'passes through null for missing refresh-on-error', ->
@@ -118,6 +150,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: null
         refreshOnErrorExcept: null
+        updatePushState: true
       )
 
     it 'passes through null for missing full-refresh-on-error-except', ->
@@ -137,6 +170,28 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: null
         refreshOnErrorExcept: 'zew'
+        updatePushState: true
+      )
+
+    it 'passes through updatePushState=false if tg-remote-nopushstate', ->
+      $link = $("<a>")
+        .attr("tg-remote", "GET")
+        .attr("refresh-on-success", "foo")
+        .attr("href", "somewhere")
+        .attr("tg-remote-nopushstate", "")
+
+      $("body").append($link)
+      $link[0].click()
+      assert.called(@Remote)
+      assert.calledWith(@Remote,
+        httpRequestType: "GET"
+        httpUrl: "somewhere"
+        fullRefresh: false
+        refreshOnSuccess: "foo"
+        refreshOnSuccessExcept: null
+        refreshOnError: null
+        refreshOnErrorExcept: null
+        updatePushState: false
       )
 
     it 'respects full-refresh-on-success-except', ->
@@ -156,6 +211,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: 'zew'
         refreshOnError: null
         refreshOnErrorExcept: null
+        updatePushState: true
       )
 
     it 'respects full-refresh', ->
@@ -177,6 +233,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
+        updatePushState: true
       )
 
     it 'does nothing if disabled', ->
@@ -210,6 +267,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
+        updatePushState: true
       )
 
       $link.remove()
@@ -233,6 +291,7 @@ describe 'Initializers', ->
         refreshOnSuccessExcept: null
         refreshOnError: "bar"
         refreshOnErrorExcept: null
+        updatePushState: true
       )
 
       $link.remove()

--- a/test/javascripts/remote_test.coffee
+++ b/test/javascripts/remote_test.coffee
@@ -293,8 +293,9 @@ describe 'Remote', ->
       remote.submit()
 
       server.respond()
-      assert @refreshStub.calledWith
+      assert.calledWith @refreshStub,
         response: sinon.match.has('responseText', '<div>Hey there</div>')
+        updatePushState: true
 
     it 'XHR=200: will trigger Page.refresh using XHR and refresh-on-success', ->
       server = sinon.fakeServer.create()
@@ -310,9 +311,30 @@ describe 'Remote', ->
       remote.submit()
 
       server.respond()
-      assert @refreshStub.calledWith
+      assert.calledWith @refreshStub,
         response: sinon.match.has('responseText', '<div>Hey there</div>')
         onlyKeys: ['a', 'b', 'c']
+        updatePushState: true
+
+    it 'XHR=200: will trigger Page.refresh with updatePushState=false if provided', ->
+      server = sinon.fakeServer.create()
+      server.respondWith("POST", "/foo/bar",
+            [200, { "Content-Type": "text/html" },
+             '<div>Hey there</div>'])
+
+      remote = new TurboGraft.Remote
+        httpRequestType: "POST"
+        httpUrl: "/foo/bar"
+        refreshOnSuccess: "a b c"
+        updatePushState: false
+      , @initiating_target
+      remote.submit()
+
+      server.respond()
+      assert.calledWith @refreshStub,
+        response: sinon.match.has('responseText', '<div>Hey there</div>')
+        onlyKeys: ['a', 'b', 'c']
+        updatePushState: false
 
     it 'XHR=200: will trigger Page.refresh using XHR and refresh-on-success-except', ->
       server = sinon.fakeServer.create()
@@ -328,9 +350,10 @@ describe 'Remote', ->
       remote.submit()
 
       server.respond()
-      assert @refreshStub.calledWith
+      assert.calledWith @refreshStub,
         response: sinon.match.has('responseText', '<div>Hey there</div>')
         exceptKeys: ['a', 'b', 'c']
+        updatePushState: true
 
     it 'XHR=200: will trigger Page.refresh with refresh-on-success when full-refresh is provided', ->
       server = sinon.fakeServer.create()
@@ -347,10 +370,11 @@ describe 'Remote', ->
 
       server.respond()
 
-      assert @refreshStub.calledWith
+      assert.calledWith @refreshStub,
         onlyKeys: ['a', 'b', 'c']
+        updatePushState: true
 
-    it 'XHR=200: will trigger Page.refresh with no arguments when full-refresh is present and refresh-on-success is not provided', ->
+    it 'XHR=200: will trigger Page.refresh with no additional arguments when full-refresh is present and refresh-on-success is not provided', ->
       server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [200, { "Content-Type": "text/html" },
@@ -364,8 +388,8 @@ describe 'Remote', ->
 
       server.respond()
 
-      assert.equal 1, @refreshStub.callCount
-      assert.equal 0, @refreshStub.args[0].length
+      assert.calledWith @refreshStub,
+        updatePushState: true
 
     it 'XHR=200: will not trigger Page.refresh when tg-remote-norefresh is present on the initiator', ->
       server = sinon.fakeServer.create()
@@ -399,9 +423,10 @@ describe 'Remote', ->
 
       server.respond()
 
-      assert @refreshStub.calledWith
+      assert.calledWith @refreshStub,
         response: sinon.match.has('responseText', '<div id="foo" refresh="foo">Error occured</div>')
         onlyKeys: ['a', 'b', 'c']
+        updatePushState: true
 
     it 'XHR=422: will trigger Page.refresh using XHR and refresh-on-error-except', ->
       server = sinon.fakeServer.create()
@@ -417,9 +442,10 @@ describe 'Remote', ->
 
       server.respond()
 
-      assert @refreshStub.calledWith
+      assert.calledWith @refreshStub,
         response: sinon.match.has('responseText', '<div id="foo" refresh="foo">Error occured</div>')
         exceptKeys: ['a', 'b', 'c']
+        updatePushState: true
 
     it 'XHR=422: will trigger Page.refresh with refresh-on-error when full-refresh is provided', ->
       server = sinon.fakeServer.create()
@@ -436,8 +462,9 @@ describe 'Remote', ->
 
       server.respond()
 
-      assert @refreshStub.calledWith
+      assert.calledWith @refreshStub,
         onlyKeys: ['a', 'b', 'c']
+        updatePushState: true
 
     it 'XHR=422: will not trigger Page.refresh if no refresh-on-error is present', ->
       server = sinon.fakeServer.create()
@@ -454,7 +481,7 @@ describe 'Remote', ->
 
       assert.equal 0, @refreshStub.callCount
 
-    it 'XHR=422: will trigger Page.refresh with no arguments when full-refresh is present and refresh-on-error is not provided', ->
+    it 'XHR=422: will trigger Page.refresh with no additional arguments when full-refresh is present and refresh-on-error is not provided', ->
       server = sinon.fakeServer.create()
       server.respondWith("POST", "/foo/bar",
             [422, { "Content-Type": "text/html" },
@@ -468,8 +495,8 @@ describe 'Remote', ->
 
       server.respond()
 
-      assert.equal 1, @refreshStub.callCount
-      assert.equal 0, @refreshStub.args[0].length
+      assert.calledWith @refreshStub,
+        updatePushState: true
 
     it 'XHR=422: will not trigger Page.refresh when tg-remote-norefresh is present on the initiator', ->
       server = sinon.fakeServer.create()


### PR DESCRIPTION
This PR allows one to add `data-tg-remote-nopushstate` to a `data-tg-remote` element.  In doing so, if the remote does a HTTP302 redirect, TG will not update the browser URL state.

The default throughout TG is `true` for `updatePushState`.  So, here, you opt in to turn it off for the 1 request

Take 2 of https://github.com/Shopify/turbograft/pull/156