### PR TITLE
Fix CI re: rails deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.byebug_history
 .bundle/
 log/*.log
 pkg/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,24 @@
 addons:
-  firefox: "49.0.2"
+  firefox: "54.0.1"
 
+dist: trusty
 language: ruby
-sudo: false
 
 cache:
   directories:
     - "travis_geckodriver"
 
 rvm:
-  - '2.3.1'
+  - '2.4.1'
 
 before_script:
   - if [ ! -d $PWD/travis_geckodriver ];  then mkdir $PWD/travis_geckodriver; fi
-  - if [ ! -f $PWD/travis_geckodriver/geckodriver ]; then wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz; fi
-  - if [ ! -f $PWD/travis_geckodriver/geckodriver ]; then tar -xvf geckodriver-v0.11.1-linux64.tar.gz -C $PWD/travis_geckodriver; fi
+  - if [ ! -f $PWD/travis_geckodriver/geckodriver ]; then wget https://github.com/mozilla/geckodriver/releases/download/v0.16.0/geckodriver-v0.16.0-linux64.tar.gz; fi
+  - if [ ! -f $PWD/travis_geckodriver/geckodriver ]; then tar -xvf geckodriver-v0.16.0-linux64.tar.gz -C $PWD/travis_geckodriver; fi
   - "export PATH=$PWD/travis_geckodriver:$PATH"
   - "geckodriver --version"
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3
-  - bundle install
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 5 # give xvfb some time to start
 
 script: bundle exec rake ci

--- a/lib/turbograft/redirection.rb
+++ b/lib/turbograft/redirection.rb
@@ -7,10 +7,9 @@ module TurboGraft
     private
     def redirect_via_turbolinks_to(url = {}, response_status = {})
       redirect_to(url, response_status)
-
       self.status           = 200
       self.response_body    = "Turbolinks.visit('#{location}');"
-      response.content_type = Mime::JS
+      response.content_type = Mime[:js]
     end
   end
 end

--- a/test/controller/legacy_pages_controller_test.rb
+++ b/test/controller/legacy_pages_controller_test.rb
@@ -15,7 +15,7 @@ class LegacyPagesControllerTest < ActionController::TestCase
     get :index
     assert_response :ok
     assert_equal "Turbolinks.visit('http://test.host/legacy_pages/1');", response.body
-    assert_equal Mime::JS, response.content_type
+    assert_equal Mime[:js], response.content_type
   end
 
   test "abort_xdomain_redirect returns 403 when cross origin" do

--- a/test/controller/pages_controller_test.rb
+++ b/test/controller/pages_controller_test.rb
@@ -15,7 +15,7 @@ class PagesControllerTest < ActionController::TestCase
     get :index
     assert_response :ok
     assert_equal "Turbolinks.visit('http://test.host/pages/1');", response.body
-    assert_equal Mime::JS, response.content_type
+    assert_equal Mime[:js], response.content_type
   end
 
   test "abort_xdomain_redirect returns 403 when cross origin" do

--- a/test/example/app/controllers/legacy_pages_controller.rb
+++ b/test/example/app/controllers/legacy_pages_controller.rb
@@ -16,7 +16,7 @@ class LegacyPagesController < ApplicationController
   end
 
   def error_500
-    render text: "Error 500!", status: 500
+    render plain: "Error 500!", status: 500
   end
 
   def error_404

--- a/test/example/app/controllers/pages_controller.rb
+++ b/test/example/app/controllers/pages_controller.rb
@@ -16,7 +16,7 @@ class PagesController < ApplicationController
   end
 
   def error_500
-    render text: "Error 500!", status: 500
+    render plain: "Error 500!", status: 500
   end
 
   def error_404

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,8 @@ require File.expand_path('../example/config/environment.rb',  __FILE__)
 require 'rails/test_help'
 
 Capybara.app = Example::Application
-Capybara.current_driver = ENV['CAPYBARA_DRIVER'] || :selenium
+# selenium_chrome may work nicely
+Capybara.current_driver = ENV['CAPYBARA_DRIVER'].try(:to_sym) || :selenium
 Capybara.default_max_wait_time = 2
 
 Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new(color: true))


### PR DESCRIPTION
This fixes CI, was able to get 🍏 twice now 🙏 

Notable changes:
- Fix Mime deprecation re: rails 5
- Fix `render text:` deprecation re: rails 5

Note that `redirect_via_turbolinks_to` is only used in the example app included in this repo, and in tests of said example app.  Perhaps it should be deleted in the future