### PR TITLE
🛠️ Make it shippable

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,9 @@
 ---
 name: turbograft
 up:
-- ruby: 2.3.1
+- ruby:
+    version: 2.3.3
+    rubygems: 2.6.13
 - bundler
 commands:
   test: bundle exec rake test

--- a/lib/assets/javascripts/turbograft/response.coffee
+++ b/lib/assets/javascripts/turbograft/response.coffee
@@ -1,11 +1,11 @@
 class TurboGraft.Response
   constructor: (@xhr, intendedURL) ->
     if intendedURL && intendedURL.withoutHash() != @xhr.responseURL
-      @redirectedTo = @xhr.responseURL
+      redirectedTo = @xhr.responseURL
     else
-      @redirectedTo = @xhr.getResponseHeader('X-XHR-Redirected-To')
+      redirectedTo = @xhr.getResponseHeader('X-XHR-Redirected-To')
 
-    @finalURL = @redirectedTo || intendedURL
+    @finalURL = redirectedTo || intendedURL
 
   valid: -> @hasRenderableHttpStatus() && @hasValidContent()
 
@@ -22,12 +22,6 @@ class TurboGraft.Response
       contentType.match(/^(?:text\/html|application\/xhtml\+xml|application\/xml)(?:;|$)/)
     else
       throw new Error("Error encountered for XHR Response: #{this}")
-
-  redirectedToNewUrl: () ->
-    Boolean(
-      @redirectedTo &&
-      @redirectedTo != TurboGraft.location()
-    )
 
   toString: () ->
     "URL: #{@xhr.responseURL}, " +

--- a/lib/assets/javascripts/turbograft/turbolinks.coffee
+++ b/lib/assets/javascripts/turbograft/turbolinks.coffee
@@ -82,7 +82,7 @@ class window.Turbolinks
       options.partialReplace ||
       options.onlyKeys?.length ||
       options.exceptKeys?.length
-    ) && !response.redirectedToNewUrl()
+    )
 
   @fullPageNavigate: (url) ->
     if url?

--- a/test/javascripts/response_test.coffee
+++ b/test/javascripts/response_test.coffee
@@ -65,33 +65,3 @@ describe 'TurboGraft.Response', ->
       responseForFixture { fixture: 'serverError' }, (response) ->
         assert.equal(response.document(), undefined)
         done()
-
-  describe 'redirectedTo', ->
-    it 'returns the responseURL if intendedURL is present and responseURL is different from passed in url', ->
-      responseForFixture { fixture: 'noScriptsOrLinkInHead', intendedURL: 'test-url' }, (response) ->
-        assert.equal(response.redirectedTo, 'noScriptsOrLinkInHead')
-        done()
-
-    it 'returns the value of the X-XHR-Redirected-To header when present', (done) ->
-      responseForFixture { fixture: 'xhrRedirectedToHeader' }, (response) ->
-        assert.equal(response.redirectedTo, ROUTES['xhrRedirectedToHeader'][1]['X-XHR-Redirected-To'])
-        done()
-
-  describe 'redirectedToNewUrl', ->
-    beforeEach ->
-      sandbox.stub(TurboGraft, 'location', -> 'test-location')
-
-    it 'returns false when no redirect header is present', (done) ->
-      responseForFixture { fixture: 'noScriptsOrLnkInHead' }, (response) ->
-        assert(!response.redirectedToNewUrl(), 'response should report that it was redirected to a new url when it has no redirect header')
-        done()
-
-    it 'returns false when a redirect header is present but matches location.href', (done) ->
-      responseForFixture { fixture: 'xhrRedirectedToHeader' }, (response) ->
-        assert.equal(response.redirectedToNewUrl(), false)
-        done()
-
-    it 'returns true when a redirect header is present and does not match location.href', (done) ->
-      responseForFixture { fixture: 'otherXhrRedirectedToHeader' }, (response) ->
-        assert.equal(response.redirectedToNewUrl(), true)
-        done()

--- a/test/javascripts/turbolinks_test.coffee
+++ b/test/javascripts/turbolinks_test.coffee
@@ -150,6 +150,30 @@ describe 'Turbolinks', ->
         assert.calledOnce(resetScrollStub)
         done()
 
+  describe 'loadPage', () ->
+    PAGE_CONTENT = 'Oh hi, mark!'
+
+    it 'is synchronous when a partial replace', ->
+      startFromFixture('noScriptsOrLinkInHead')
+      xhr = new sinon.FakeXMLHttpRequest()
+      xhr.open('POST', '/my/endpoint', true)
+      xhr.respond(200, {'Content-Type':'text/html'}, PAGE_CONTENT)
+
+      Turbolinks.loadPage(null, xhr, {partialReplace: true})
+
+      assert.include(testDocument.body.textContent, PAGE_CONTENT)
+
+    it 'is asynchronous when not a partial replace', (done) ->
+      startFromFixture('noScriptsOrLinkInHead')
+      xhr = new sinon.FakeXMLHttpRequest()
+      xhr.open('POST', '/my/endpoint', true)
+      xhr.respond(200, {'Content-Type':'text/html'}, PAGE_CONTENT)
+
+      Turbolinks.loadPage(null, xhr).then () ->
+        assert.include(testDocument.body.textContent, PAGE_CONTENT)
+        done()
+      assert.notInclude(testDocument.body.textContent, PAGE_CONTENT)
+
   describe 'head asset tracking', ->
     it 'refreshes page when moving from a page with tracked assets to a page with none', (done) ->
       startFromFixture('singleScriptInHead')


### PR DESCRIPTION

## Summary
This PR aims to make TG shippable again.

## The Problem
We've been unable to deploy the latest version of TG in our apps because we relied on some quirky behaviour. Namely, we have multiple call-sites that pass an XHR into `page.refresh` which already has listeners on it, intending those listeners to be invoked after the replace has occurred. The problem arises because changes to loadPage's implementation meant that some of these (which resulted in redirects) were (correctly) detected to not be true partial replaces (they redirected to other routes) and ideally should have head asset tracking.  Since head asset tracking needs to be asynchronous, the code was rendered broken.

TG does have an api for doing things after a particular refresh, with the `callback` option, but these weird cases are very hard to grep for and can be convoluted to switch over.

## The Solution
To make this shippable, we make it so that:
- redirects no longer override `partialReplace: false`
- `page.refresh(xhr, {partial: true})` are always synchronous

## 🎩  instructions
- point your project at your local copy of this branch with `path: 'path/to/turbograft'` in your gemfile
- navigate about, complete user flows, go to places that have redirects
- observe whether things break

## Closing
It's not ideal, but with our eventual goal being to switch over to our react stack imo it's best to just get this shippable so we can fix bugs (and / or add any necessary features) in the interim.

Feel free to ping me on slack for more context.
